### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-darwin-arm64",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TPS CLI native binary for darwin-arm64",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-darwin-x64",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TPS CLI native binary for darwin-x64",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/packages/cli-linux-arm64/package.json
+++ b/packages/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-linux-arm64",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TPS CLI native binary for linux-arm64",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/packages/cli-linux-x64/package.json
+++ b/packages/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-linux-x64",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TPS CLI native binary for linux-x64",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@tpsdev-ai/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TPS Report CLI — because every agent needs the proper paperwork.",
   "type": "module",
   "bin": {
     "tps": "./bin/tps.cjs"
   },
   "optionalDependencies": {
-    "@tpsdev-ai/cli-darwin-arm64": "0.3.1",
-    "@tpsdev-ai/cli-darwin-x64": "0.3.1",
-    "@tpsdev-ai/cli-linux-arm64": "0.3.1",
-    "@tpsdev-ai/cli-linux-x64": "0.3.1"
+    "@tpsdev-ai/cli-darwin-arm64": "0.3.2",
+    "@tpsdev-ai/cli-darwin-x64": "0.3.2",
+    "@tpsdev-ai/cli-linux-arm64": "0.3.2",
+    "@tpsdev-ai/cli-linux-x64": "0.3.2"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Patch release with working binary (react-devtools-core bundled).