### PR TITLE
fix: add @tpsdev-ai/agent as cli dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
     },
     "packages/cli": {
       "name": "@tpsdev-ai/cli",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "bin": {
         "tps": "./bin/tps.cjs",
       },
@@ -39,6 +39,7 @@
         "@noble/ed25519": "^3.0.0",
         "@noble/hashes": "^2.0.1",
         "@node-rs/argon2": "^2.0.2",
+        "@tpsdev-ai/agent": "workspace:*",
         "@types/ws": "^8.18.1",
         "handlebars": "^4.7.8",
         "ink": "^5.2.0",
@@ -59,36 +60,36 @@
         "typescript": "^5.7.0",
       },
       "optionalDependencies": {
-        "@tpsdev-ai/cli-darwin-arm64": "0.3.5",
-        "@tpsdev-ai/cli-darwin-x64": "0.3.5",
-        "@tpsdev-ai/cli-linux-arm64": "0.3.5",
-        "@tpsdev-ai/cli-linux-x64": "0.3.5",
+        "@tpsdev-ai/cli-darwin-arm64": "0.4.0",
+        "@tpsdev-ai/cli-darwin-x64": "0.4.0",
+        "@tpsdev-ai/cli-linux-arm64": "0.4.0",
+        "@tpsdev-ai/cli-linux-x64": "0.4.0",
       },
     },
     "packages/cli-darwin-arm64": {
       "name": "@tpsdev-ai/cli-darwin-arm64",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "bin": {
         "tps": "./tps",
       },
     },
     "packages/cli-darwin-x64": {
       "name": "@tpsdev-ai/cli-darwin-x64",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "bin": {
         "tps": "./tps",
       },
     },
     "packages/cli-linux-arm64": {
       "name": "@tpsdev-ai/cli-linux-arm64",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "bin": {
         "tps": "./tps",
       },
     },
     "packages/cli-linux-x64": {
       "name": "@tpsdev-ai/cli-linux-x64",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "bin": {
         "tps": "./tps",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,8 @@
     "noise-handshake": "^4.2.0",
     "react": "^18.3.1",
     "ws": "^8.19.0",
-    "zod": "^3.24.0"
+    "zod": "^3.24.0",
+    "@tpsdev-ai/agent": "workspace:*"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",


### PR DESCRIPTION
Binary build fails because `packages/cli/src/commands/agent.ts` imports `@tpsdev-ai/agent` but it wasn't declared in cli's `package.json`. This adds it as a workspace dependency so `bun build --compile` can resolve it.

Blocks v0.4.0 release.