### PR TITLE
fix: add build step before binary compile in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,8 @@ jobs:
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
+      - name: Build workspace packages
+        run: bun run build
       - name: Build ${TARGET}
         env:
           TARGET: ${{ matrix.target }}

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tpsdev-ai/agent",
-  "version": "0.2.0",
-  "description": "Native TPS Agent Runtime — headless, mail-driven, nono-sandboxed",
+  "version": "0.4.0",
+  "description": "Native TPS Agent Runtime \u2014 headless, mail-driven, nono-sandboxed",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,7 +25,12 @@
     "lint": "biome lint ./src",
     "lint:ci": "biome lint ./src --max-diagnostics=200"
   },
-  "keywords": ["agents", "tps", "runtime", "mail-driven"],
+  "keywords": [
+    "agents",
+    "tps",
+    "runtime",
+    "mail-driven"
+  ],
   "license": "Apache-2.0",
   "dependencies": {
     "js-yaml": "^4.1.0",
@@ -39,5 +44,7 @@
     "typescript": "^5.7.0"
   },
   "author": "tpsdev-ai",
-  "publishConfig": { "access": "public" }
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
Release workflow fails because `bun build --compile` can't resolve `@tpsdev-ai/agent` workspace package. Adding `bun run build` before compile ensures workspace packages are built first.

Also bumps `@tpsdev-ai/agent` to 0.4.0.