### PR TITLE
fix: move @tpsdev-ai/agent to devDependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,25 @@ jobs:
           cp -R /tmp/release/cli-darwin-x64/. packages/cli-darwin-x64/
           cp -R /tmp/release/cli-linux-arm64/. packages/cli-linux-arm64/
           cp -R /tmp/release/cli-linux-x64/. packages/cli-linux-x64/
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - name: Build agent package
+        run: bun run --filter @tpsdev-ai/agent build
+      - name: Publish agent package
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          npm publish --access public --workspace @tpsdev-ai/agent || {
+            if npm view "@tpsdev-ai/agent@$VERSION" version 2>/dev/null; then
+              echo "⏭️ @tpsdev-ai/agent@$VERSION already published, skipping"
+            else
+              echo "❌ Failed to publish @tpsdev-ai/agent" && exit 1
+            fi
+          }
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish platform packages
         run: |
           VERSION="${{ github.ref_name }}"

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/agent": {
       "name": "@tpsdev-ai/agent",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "bin": {
         "tps-agent": "./dist/bin.js",
       },
@@ -39,7 +39,6 @@
         "@noble/ed25519": "^3.0.0",
         "@noble/hashes": "^2.0.1",
         "@node-rs/argon2": "^2.0.2",
-        "@tpsdev-ai/agent": "workspace:*",
         "@types/ws": "^8.18.1",
         "handlebars": "^4.7.8",
         "ink": "^5.2.0",
@@ -53,6 +52,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
+        "@tpsdev-ai/agent": "workspace:*",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "@types/react": "^18.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,8 +48,7 @@
     "noise-handshake": "^4.2.0",
     "react": "^18.3.1",
     "ws": "^8.19.0",
-    "zod": "^3.24.0",
-    "@tpsdev-ai/agent": "workspace:*"
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
@@ -57,7 +56,8 @@
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.0",
     "fast-check": "^4.5.3",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "@tpsdev-ai/agent": "workspace:*"
   },
   "files": [
     "bin",


### PR DESCRIPTION
`workspace:*` can't be resolved from npm registry. The agent package is bundled into the binary at build time — it's a build dep, not a runtime dep.

Blocks v0.4.0 npm install.