### PR TITLE
fix: replace argon2 native addon with built-in scrypt + fix binary resolution

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/agent": {
       "name": "@tpsdev-ai/agent",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "tps-agent": "./dist/bin.js",
       },
@@ -30,7 +30,7 @@
     },
     "packages/cli": {
       "name": "@tpsdev-ai/cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "tps": "./bin/tps.cjs",
       },
@@ -38,7 +38,6 @@
         "@noble/curves": "^2.0.1",
         "@noble/ed25519": "^3.0.0",
         "@noble/hashes": "^2.0.1",
-        "@node-rs/argon2": "^2.0.2",
         "@types/ws": "^8.18.1",
         "handlebars": "^4.7.8",
         "ink": "^5.2.0",
@@ -60,36 +59,36 @@
         "typescript": "^5.7.0",
       },
       "optionalDependencies": {
-        "@tpsdev-ai/cli-darwin-arm64": "0.4.0",
-        "@tpsdev-ai/cli-darwin-x64": "0.4.0",
-        "@tpsdev-ai/cli-linux-arm64": "0.4.0",
-        "@tpsdev-ai/cli-linux-x64": "0.4.0",
+        "@tpsdev-ai/cli-darwin-arm64": "0.4.1",
+        "@tpsdev-ai/cli-darwin-x64": "0.4.1",
+        "@tpsdev-ai/cli-linux-arm64": "0.4.1",
+        "@tpsdev-ai/cli-linux-x64": "0.4.1",
       },
     },
     "packages/cli-darwin-arm64": {
       "name": "@tpsdev-ai/cli-darwin-arm64",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "tps": "./tps",
       },
     },
     "packages/cli-darwin-x64": {
       "name": "@tpsdev-ai/cli-darwin-x64",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "tps": "./tps",
       },
     },
     "packages/cli-linux-arm64": {
       "name": "@tpsdev-ai/cli-linux-arm64",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "tps": "./tps",
       },
     },
     "packages/cli-linux-x64": {
       "name": "@tpsdev-ai/cli-linux-x64",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "tps": "./tps",
       },
@@ -116,12 +115,6 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A=="],
 
-    "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
-
-    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
-
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
-
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="],
@@ -134,43 +127,11 @@
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
-
     "@noble/curves": ["@noble/curves@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1" } }, "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw=="],
 
     "@noble/ed25519": ["@noble/ed25519@3.0.0", "", {}, "sha512-QyteqMNm0GLqfa5SoYbSC3+Pvykwpn95Zgth4MFVSMKBB75ELl9tX1LAVsN4c3HXOrakHsF2gL4zWDAYCcsnzg=="],
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
-
-    "@node-rs/argon2": ["@node-rs/argon2@2.0.2", "", { "optionalDependencies": { "@node-rs/argon2-android-arm-eabi": "2.0.2", "@node-rs/argon2-android-arm64": "2.0.2", "@node-rs/argon2-darwin-arm64": "2.0.2", "@node-rs/argon2-darwin-x64": "2.0.2", "@node-rs/argon2-freebsd-x64": "2.0.2", "@node-rs/argon2-linux-arm-gnueabihf": "2.0.2", "@node-rs/argon2-linux-arm64-gnu": "2.0.2", "@node-rs/argon2-linux-arm64-musl": "2.0.2", "@node-rs/argon2-linux-x64-gnu": "2.0.2", "@node-rs/argon2-linux-x64-musl": "2.0.2", "@node-rs/argon2-wasm32-wasi": "2.0.2", "@node-rs/argon2-win32-arm64-msvc": "2.0.2", "@node-rs/argon2-win32-ia32-msvc": "2.0.2", "@node-rs/argon2-win32-x64-msvc": "2.0.2" } }, "sha512-t64wIsPEtNd4aUPuTAyeL2ubxATCBGmeluaKXEMAFk/8w6AJIVVkeLKMBpgLW6LU2t5cQxT+env/c6jxbtTQBg=="],
-
-    "@node-rs/argon2-android-arm-eabi": ["@node-rs/argon2-android-arm-eabi@2.0.2", "", { "os": "android", "cpu": "arm" }, "sha512-DV/H8p/jt40lrao5z5g6nM9dPNPGEHL+aK6Iy/og+dbL503Uj0AHLqj1Hk9aVUSCNnsDdUEKp4TVMi0YakDYKw=="],
-
-    "@node-rs/argon2-android-arm64": ["@node-rs/argon2-android-arm64@2.0.2", "", { "os": "android", "cpu": "arm64" }, "sha512-1LKwskau+8O1ktKx7TbK7jx1oMOMt4YEXZOdSNIar1TQKxm6isZ0cRXgHLibPHEcNHgYRsJWDE9zvDGBB17QDg=="],
-
-    "@node-rs/argon2-darwin-arm64": ["@node-rs/argon2-darwin-arm64@2.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3TTNL/7wbcpNju5YcqUrCgXnXUSbD7ogeAKatzBVHsbpjZQbNb1NDxDjqqrWoTt6XL3z9mJUMGwbAk7zQltHtA=="],
-
-    "@node-rs/argon2-darwin-x64": ["@node-rs/argon2-darwin-x64@2.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-vNPfkLj5Ij5111UTiYuwgxMqE7DRbOS2y58O2DIySzSHbcnu+nipmRKg+P0doRq6eKIJStyBK8dQi5Ic8pFyDw=="],
-
-    "@node-rs/argon2-freebsd-x64": ["@node-rs/argon2-freebsd-x64@2.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-M8vQZk01qojQfCqQU0/O1j1a4zPPrz93zc9fSINY7Q/6RhQRBCYwDw7ltDCZXg5JRGlSaeS8cUXWyhPGar3cGg=="],
-
-    "@node-rs/argon2-linux-arm-gnueabihf": ["@node-rs/argon2-linux-arm-gnueabihf@2.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-7EmmEPHLzcu0G2GDh30L6G48CH38roFC2dqlQJmtRCxs6no3tTE/pvgBGatTp/o2n2oyOJcfmgndVFcUpwMnww=="],
-
-    "@node-rs/argon2-linux-arm64-gnu": ["@node-rs/argon2-linux-arm64-gnu@2.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-6lsYh3Ftbk+HAIZ7wNuRF4SZDtxtFTfK+HYFAQQyW7Ig3LHqasqwfUKRXVSV5tJ+xTnxjqgKzvZSUJCAyIfHew=="],
-
-    "@node-rs/argon2-linux-arm64-musl": ["@node-rs/argon2-linux-arm64-musl@2.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA=="],
-
-    "@node-rs/argon2-linux-x64-gnu": ["@node-rs/argon2-linux-x64-gnu@2.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA=="],
-
-    "@node-rs/argon2-linux-x64-musl": ["@node-rs/argon2-linux-x64-musl@2.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw=="],
-
-    "@node-rs/argon2-wasm32-wasi": ["@node-rs/argon2-wasm32-wasi@2.0.2", "", { "dependencies": { "@napi-rs/wasm-runtime": "^0.2.5" }, "cpu": "none" }, "sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ=="],
-
-    "@node-rs/argon2-win32-arm64-msvc": ["@node-rs/argon2-win32-arm64-msvc@2.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Eisd7/NM0m23ijrGr6xI2iMocdOuyl6gO27gfMfya4C5BODbUSP7ljKJ7LrA0teqZMdYHesRDzx36Js++/vhiQ=="],
-
-    "@node-rs/argon2-win32-ia32-msvc": ["@node-rs/argon2-win32-ia32-msvc@2.0.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-GsE2ezwAYwh72f9gIjbGTZOf4HxEksb5M2eCaj+Y5rGYVwAdt7C12Q2e9H5LRYxWcFvLH4m4jiSZpQQ4upnPAQ=="],
-
-    "@node-rs/argon2-win32-x64-msvc": ["@node-rs/argon2-win32-x64-msvc@2.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-cJxWXanH4Ew9CfuZ4IAEiafpOBCe97bzoKowHCGk5lG/7kR4WF/eknnBlHW9m8q7t10mKq75kruPLtbSDqgRTw=="],
 
     "@tpsdev-ai/agent": ["@tpsdev-ai/agent@workspace:packages/agent"],
 
@@ -183,8 +144,6 @@
     "@tpsdev-ai/cli-linux-arm64": ["@tpsdev-ai/cli-linux-arm64@workspace:packages/cli-linux-arm64"],
 
     "@tpsdev-ai/cli-linux-x64": ["@tpsdev-ai/cli-linux-x64@workspace:packages/cli-linux-x64"],
-
-    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
@@ -315,8 +274,6 @@
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 

--- a/packages/cli/bin/tps.cjs
+++ b/packages/cli/bin/tps.cjs
@@ -1,24 +1,31 @@
 #!/usr/bin/env node
 
 const { execFileSync } = require('child_process');
+const path = require('path');
 
 const platform = process.platform;
 const arch = process.arch;
 const pkg = `@tpsdev-ai/cli-${platform}-${arch}`;
 
+// Search for the platform binary relative to this package, not the cwd.
+// npm nests optionalDependencies inside the parent's node_modules.
+const searchPaths = [path.join(__dirname, '..'), path.join(__dirname, '..', '..')];
+
 function runBinary() {
   try {
-    const path = require('path');
-    const pkgJson = require.resolve(`${pkg}/package.json`);
+    const pkgJson = require.resolve(`${pkg}/package.json`, { paths: searchPaths });
     const binPath = path.join(path.dirname(pkgJson), 'tps');
     execFileSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
     return;
   } catch (err) {
-    console.error(`TPS: no binary package available for ${platform}-${arch}.`);
-    console.error(`Run npm install -g ${pkg} to install the platform binary package.`);
-    console.error('Or run from source inside the repository via `bun run tps` in packages/cli.');
-    process.exitCode = 1;
+    // Fall through to error message
   }
+
+  console.error(`Failed to load native binding`);
+  console.error(`TPS: no binary package available for ${platform}-${arch}.`);
+  console.error(`Run npm install -g ${pkg} to install the platform binary package.`);
+  console.error('Or run from source inside the repository via `bun run tps` in packages/cli.');
+  process.exitCode = 1;
 }
 
 runBinary();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,6 @@
     "@noble/curves": "^2.0.1",
     "@noble/ed25519": "^3.0.0",
     "@noble/hashes": "^2.0.1",
-    "@node-rs/argon2": "^2.0.2",
     "@types/ws": "^8.18.1",
     "handlebars": "^4.7.8",
     "ink": "^5.2.0",

--- a/packages/cli/src/utils/vault.ts
+++ b/packages/cli/src/utils/vault.ts
@@ -1,5 +1,4 @@
-import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
-import { hashRaw, Algorithm } from "@node-rs/argon2";
+import { randomBytes, createCipheriv, createDecipheriv, scryptSync } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 
@@ -10,30 +9,28 @@ export interface VaultData {
   authTag: string;    // base64
   ciphertext: string; // base64
   kdf?: {
-    m: number;
-    t: number;
-    p: number;
+    n: number;  // CPU/memory cost (scrypt N)
+    r: number;  // block size
+    p: number;  // parallelism
   };
 }
 
-// Default KDF parameters
-const DEFAULT_KDF = { m: 65536, t: 3, p: 4 };
+// Default KDF parameters (scrypt)
+// N=2^17 (~128MB), r=8, p=1 — comparable security to argon2id defaults
+const DEFAULT_KDF = { n: 131072, r: 8, p: 1 };
 
-// Derive a 32-byte key using Argon2id
+// Derive a 32-byte key using scrypt (built-in, no native deps)
 export async function deriveKey(
   passphrase: string, 
   salt: Buffer, 
   params = DEFAULT_KDF
 ): Promise<Buffer> {
-  const key = await hashRaw(passphrase, {
-    algorithm: Algorithm.Argon2id,
-    memoryCost: params.m,
-    timeCost: params.t,
-    parallelism: params.p,
-    outputLen: 32,
-    salt,
+  return scryptSync(passphrase, salt, 32, {
+    N: params.n,
+    r: params.r,
+    p: params.p,
+    maxmem: params.n * params.r * 256,
   });
-  return Buffer.from(key);
 }
 
 export async function encryptVault(data: any, passphrase: string): Promise<VaultData> {
@@ -64,8 +61,8 @@ export async function decryptVault(vault: VaultData, passphrase: string): Promis
   const authTag = Buffer.from(vault.authTag, "base64");
   
   const params = {
-    m: vault.kdf?.m ?? DEFAULT_KDF.m,
-    t: vault.kdf?.t ?? DEFAULT_KDF.t,
+    n: vault.kdf?.n ?? DEFAULT_KDF.n,
+    r: vault.kdf?.r ?? DEFAULT_KDF.r,
     p: vault.kdf?.p ?? DEFAULT_KDF.p,
   };
 


### PR DESCRIPTION
Two issues that have been breaking the compiled binary since day one:

**1. Native addon crash**
`@node-rs/argon2` is a Rust native addon that can't be bundled by `bun build --compile`. Every compiled binary has failed with `Failed to load native binding`. Replaced with Node's built-in `crypto.scryptSync` — zero native deps, comparable security (N=2^17, r=8, p=1).

**2. CJS wrapper path resolution**
`require.resolve()` searched from cwd instead of the package directory. Added `{ paths: [__dirname/..] }` so it finds the nested platform binary.

Verified locally: `bun build --compile` produces a working binary that runs `tps office list` correctly.