### PR TITLE
chore: bump to 0.4.2 — working binary distribution

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/agent",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Native TPS Agent Runtime \u2014 headless, mail-driven, nono-sandboxed",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-darwin-arm64",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TPS CLI native binary for darwin-arm64",
   "os": [
     "darwin"

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-darwin-x64",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TPS CLI native binary for darwin-x64",
   "os": [
     "darwin"

--- a/packages/cli-linux-arm64/package.json
+++ b/packages/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-linux-arm64",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TPS CLI native binary for linux-arm64",
   "os": [
     "linux"

--- a/packages/cli-linux-x64/package.json
+++ b/packages/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-linux-x64",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TPS CLI native binary for linux-x64",
   "os": [
     "linux"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@tpsdev-ai/cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TPS Report CLI \u2014 because every agent needs the proper paperwork.",
   "type": "module",
   "bin": {
     "tps": "./bin/tps.cjs"
   },
   "optionalDependencies": {
-    "@tpsdev-ai/cli-darwin-arm64": "0.4.1",
-    "@tpsdev-ai/cli-darwin-x64": "0.4.1",
-    "@tpsdev-ai/cli-linux-arm64": "0.4.1",
-    "@tpsdev-ai/cli-linux-x64": "0.4.1"
+    "@tpsdev-ai/cli-darwin-arm64": "0.4.2",
+    "@tpsdev-ai/cli-darwin-x64": "0.4.2",
+    "@tpsdev-ai/cli-linux-arm64": "0.4.2",
+    "@tpsdev-ai/cli-linux-x64": "0.4.2"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
First release where `npm install -g @tpsdev-ai/cli && tps office list` actually works end to end.