### PR TITLE
CP33B Part 1: daemon entrypoints for tps-agent

### DIFF
--- a/packages/agent/src/bin.ts
+++ b/packages/agent/src/bin.ts
@@ -3,38 +3,58 @@ import { AgentRuntime } from "./runtime/agent.js";
 import { loadAgentConfig } from "./config.js";
 
 function usage(): never {
-  console.error("Usage: tps-agent run --config <agent.yaml> --message <text>");
+  console.error("Usage:");
+  console.error("  tps-agent run --config <agent.yaml> --message <text>");
+  console.error("  tps-agent start --config <agent.yaml>");
+  console.error("  tps-agent health --config <agent.yaml>");
   process.exit(1);
+}
+
+function parseArg(name: string, args: string[]): string | undefined {
+  const idx = args.indexOf(name);
+  if (idx >= 0 && idx + 1 < args.length) return args[idx + 1];
+  return undefined;
+}
+
+function parseConfig(args: string[]): { configPath?: string; command?: string } {
+  const command = args[0];
+  const configPath = parseArg("--config", args);
+  return { command, configPath };
 }
 
 async function main() {
   const args = process.argv.slice(2);
-  const cmd = args[0];
-
-  if (cmd !== "run") {
-    usage();
-  }
-
-  const configIdx = args.indexOf("--config");
-  const msgIdx = args.indexOf("--message");
-
-  if (configIdx < 0 || msgIdx < 0) {
-    usage();
-  }
-
-  const configPath = args[configIdx + 1];
-  const message = args.slice(msgIdx + 1).join(" ");
-
-  if (!configPath || !message) {
-    usage();
-  }
+  const { command, configPath } = parseConfig(args);
+  if (!command || command === "--help" || command === "-h") usage();
+  if (!configPath) usage();
 
   const config = loadAgentConfig(configPath);
   const runtime = new AgentRuntime(config);
-  await runtime.runOnce(message);
+
+  switch (command) {
+    case "run": {
+      const messageIdx = args.indexOf("--message");
+      const message = messageIdx >= 0 ? args.slice(messageIdx + 1).join(" ") : process.env.TPS_AGENT_MESSAGE;
+      if (!message) usage();
+      await runtime.runOnce(message);
+      return;
+    }
+    case "start": {
+      await runtime.start();
+      return;
+    }
+    case "health": {
+      const healthy = runtime.isHealthy();
+      process.stdout.write(healthy ? "healthy\n" : "unhealthy\n");
+      process.exit(healthy ? 0 : 1);
+      return;
+    }
+    default:
+      usage();
+  }
 }
 
 main().catch((err) => {
-  console.error(err?.message || err);
+  console.error(String(err?.message || err));
   process.exit(1);
 });

--- a/packages/agent/src/runtime/agent.ts
+++ b/packages/agent/src/runtime/agent.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
 import type { AgentConfig } from "./types.js";
 import { EventLoop } from "./event-loop.js";
 import { MailClient } from "../io/mail.js";
@@ -32,7 +34,24 @@ export class AgentRuntime {
 
   async start(): Promise<void> {
     const checkInbox = async () => this.mail.checkNewMail();
-    await this.loop.run(checkInbox);
+    const pidPath = join(this.config.workspace, ".tps-agent.pid");
+    mkdirSync(dirname(pidPath), { recursive: true });
+    writeFileSync(pidPath, `${process.pid}\n`, "utf-8");
+
+    const shutdown = new Promise<void>((resolve) => {
+      const onStop = async () => {
+        await this.loop.stop();
+        resolve();
+      };
+      process.once("SIGINT", onStop);
+      process.once("SIGTERM", onStop);
+    });
+
+    try {
+      await Promise.race([this.loop.run(checkInbox), shutdown]);
+    } finally {
+      rmSync(pidPath, { force: true });
+    }
   }
 
   async stop(): Promise<void> {
@@ -45,6 +64,10 @@ export class AgentRuntime {
 
   getState(): string {
     return this.loop.getState();
+  }
+
+  isHealthy(): boolean {
+    return this.getState() !== "stopped";
   }
 
   describeBoundaries(): string {

--- a/packages/agent/src/runtime/event-loop.ts
+++ b/packages/agent/src/runtime/event-loop.ts
@@ -1,12 +1,5 @@
 import type { MailMessage } from "../io/mail.js";
-import type {
-  AgentConfig,
-  AgentState,
-  CompletionRequest,
-  CompletionResponse,
-  ToolCall,
-  ToolSpec,
-} from "./types.js";
+import type { AgentConfig, CompletionRequest, ToolCall, ToolSpec, AgentState } from "./types.js";
 import type { MemoryStore } from "../io/memory.js";
 import type { ContextManager } from "../io/context.js";
 import type { ProviderManager } from "../llm/provider.js";
@@ -72,7 +65,8 @@ export class EventLoop {
   }
 
   private async processMail(message: MailMessage): Promise<void> {
-    await this.processMessage(message.body);
+    const body = typeof message.body === "string" ? message.body : JSON.stringify(message.body);
+    await this.processMessage(body);
   }
 
   private async processMessage(promptRaw: string): Promise<void> {
@@ -96,15 +90,14 @@ export class EventLoop {
       data: { direction: "in", body: prompt },
     });
 
-    const request: CompletionRequest = {
+    let completion = await this.deps.provider.complete({
       systemPrompt: await this.buildSystemPrompt(),
       messages: [{ role: "user", content: prompt }],
       tools,
       toolChoice: "auto",
       maxTokens: this.deps.config.maxTokens ?? 1024,
-    };
+    });
 
-    let completion = await this.deps.provider.complete(request);
     let turns = 0;
 
     while (true) {
@@ -120,9 +113,7 @@ export class EventLoop {
         });
       }
 
-      if (!completion.toolCalls || completion.toolCalls.length === 0) {
-        return;
-      }
+      if (!completion.toolCalls || completion.toolCalls.length === 0) return;
 
       if (turns++ > 8) {
         await this.deps.memory.append({
@@ -141,8 +132,9 @@ export class EventLoop {
           data: { tool: call.name, args: call.input },
         });
 
-        if (this.deps.reviewGate && this.deps.reviewGate.isHighRisk(call.name)) {
-          await this.deps.reviewGate.requestApproval(call.name, call.input);
+        const reviewBlocked = this.deps.reviewGate?.isHighRisk(call.name) ?? false;
+        if (reviewBlocked) {
+          await this.deps.reviewGate!.requestApproval(call.name, call.input);
           await this.deps.memory.append({
             type: "approval_request",
             ts: new Date().toISOString(),
@@ -172,15 +164,13 @@ export class EventLoop {
         });
       }
 
-      const nextMessages = [
-        ...request.messages,
-        { role: "assistant", content: completion.content ?? "" },
-        ...toolMessages,
-      ];
-
       completion = await this.deps.provider.complete({
-        systemPrompt: request.systemPrompt,
-        messages: nextMessages,
+        systemPrompt: await this.buildSystemPrompt(),
+        messages: [
+          { role: "user", content: prompt },
+          { role: "assistant", content: completion.content ?? "" },
+          ...toolMessages,
+        ] as any,
         tools,
         toolChoice: "auto",
         maxTokens: this.deps.config.maxTokens ?? 1024,
@@ -189,7 +179,6 @@ export class EventLoop {
   }
 
   private async buildSystemPrompt(): Promise<string> {
-    const fs = await import("node:fs/promises");
     const docs = await Promise.all([
       this.fileOrEmpty(`${this.deps.config.workspace}/SOUL.md`),
       this.fileOrEmpty(`${this.deps.config.workspace}/AGENTS.md`),
@@ -197,14 +186,13 @@ export class EventLoop {
       Promise.resolve(this.deps.config.systemPrompt || ""),
     ]);
 
-    const sections = [
+    const docBlock = docs.filter(Boolean).join("\n\n");
+    return [
+      docBlock,
       `Role: ${this.deps.config.name}`,
       `Tools: ${this.deps.tools.list().map((t) => t.name).join(", ") || "(none)"}`,
       `Context: ${this.deps.config.agentId}`,
-    ];
-
-    const docBlock = docs.filter(Boolean).join("\n\n");
-    return `${docBlock}\n\n${sections.join("\n")}`;
+    ].join("\n");
   }
 
   private async fileOrEmpty(path: string): Promise<string> {

--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -18,7 +18,7 @@ const cli = meow(
     heartbeat <agent-id> [--nonono] Send a heartbeat/ping for an agent
     context <action>  Workstream context memory (read/update/list)
     mail <action>     Mailroom operations (send/check/list/search)
-    agent run          Run tps-agent one-shot run (from config)
+    agent run|start|health  Manage tps-agent runtime from config
     identity <action> Key management (init/show/register/list/revoke/verify)
     secrets <action>  Secret management (set/list/remove)
     git <action>      Git utilities (worktree)
@@ -202,27 +202,34 @@ async function main() {
     }
 
     case "agent": {
-      if (rest[0] !== "run") {
-        console.error("Usage: tps agent run --config <path> --message <text>");
+      const action = rest[0] as "run" | "start" | "health" | undefined;
+      if (!action || !["run", "start", "health"].includes(action)) {
+        console.error("Usage:\n  tps agent run --config <path> --message <text>\n  tps agent start --config <path>\n  tps agent health --config <path>");
         process.exit(1);
       }
 
       const cfgIdx = process.argv.indexOf("--config");
-      const msgIdx = process.argv.indexOf("--message");
-      if (cfgIdx < 0 || msgIdx < 0) {
-        console.error("Usage: tps agent run --config <path> --message <text>");
+      if (cfgIdx < 0) {
+        console.error("Usage: tps agent <run|start|health> --config <path> [--message <text>]");
         process.exit(1);
       }
 
       const configPath = process.argv[cfgIdx + 1];
-      const message = process.argv.slice(msgIdx + 1).join(" ");
-      if (!configPath || !message) {
-        console.error("Usage: tps agent run --config <path> --message <text>");
+      if (!configPath) {
+        console.error("Usage: tps agent <run|start|health> --config <path> [--message <text>]");
         process.exit(1);
       }
 
       const { runAgent } = await import("../src/commands/agent.js");
-      await runAgent({ action: "run", config: configPath, message });
+      if (action === "run") {
+        const msgIdx = process.argv.indexOf("--message");
+        const message = msgIdx >= 0 ? process.argv.slice(msgIdx + 1).join(" ") : undefined;
+        await runAgent({ action: "run", config: configPath, message });
+      } else if (action === "start") {
+        await runAgent({ action: "start", config: configPath });
+      } else {
+        await runAgent({ action: "health", config: configPath });
+      }
       break;
     }
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1,27 +1,33 @@
 import { AgentRuntime, loadAgentConfig } from "@tpsdev-ai/agent";
 
 export interface AgentArgs {
-  action: "run";
+  action: "run" | "start" | "health";
   config: string;
   message?: string;
 }
 
 export async function runAgent(args: AgentArgs): Promise<void> {
-  if (args.action !== "run") {
-    console.error("Usage: tps agent run --config <agent.yaml> --message <text>");
-    process.exit(1);
-  }
+  const config = loadAgentConfig(args.config);
+  const runtime = new AgentRuntime(config);
 
-  if (!args.message) {
-    const message = process.env.TPS_AGENT_MESSAGE;
+  if (args.action === "run") {
+    const message = args.message || process.env.TPS_AGENT_MESSAGE;
     if (!message) {
       console.error("Usage: tps agent run --config <agent.yaml> --message <text>");
       process.exit(1);
     }
-    args.message = message;
+    await runtime.runOnce(message);
+    return;
   }
 
-  const config = loadAgentConfig(args.config);
-  const runtime = new AgentRuntime(config);
-  await runtime.runOnce(args.message);
+  if (args.action === "start") {
+    await runtime.start();
+    return;
+  }
+
+  if (args.action === "health") {
+    const healthy = runtime.isHealthy();
+    process.stdout.write(healthy ? "healthy\n" : "unhealthy\n");
+    process.exit(healthy ? 0 : 1);
+  }
 }


### PR DESCRIPTION
Implements CP33B first deliverable: daemon entrypoints and lifecycle wiring.\n\nIncluded:\n- tps-agent bin supports: run, start, health\n- runtime.start() writes/removes PID file and handles SIGINT/SIGTERM graceful shutdown\n- event loop cleanup and stability fixes for daemon polling path\n-  CLI supports run/start/health commands\n\nValidation:\n- packages/agent: bun run build && bun test\n- repo: bun test (730 pass)\n