### PR TITLE
CP33B Part 2: env var interpolation in agent config

### DIFF
--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -22,9 +22,40 @@ export interface AgentRuntimeConfig {
   execAllowlist?: string[];
 }
 
+function interpolateEnvInString(raw: string): string {
+  return raw.replace(/\$\{([A-Z0-9_]+)\}/g, (_match, varName: string) => {
+    const resolved = process.env[varName];
+    if (resolved === undefined) {
+      throw new Error(`Missing environment variable: ${varName}`);
+    }
+    return resolved;
+  });
+}
+
+function interpolateEnvVars<T>(value: T): T {
+  if (typeof value === "string") {
+    return interpolateEnvInString(value) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => interpolateEnvVars(item)) as T;
+  }
+
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = interpolateEnvVars(v);
+    }
+    return out as T;
+  }
+
+  return value;
+}
+
 export function loadAgentConfig(path: string): AgentConfig {
   const raw = readFileSync(path, "utf-8");
-  const parsed = (yaml.load(raw) ?? {}) as Record<string, any>;
+  const parsedRaw = (yaml.load(raw) ?? {}) as Record<string, any>;
+  const parsed = interpolateEnvVars(parsedRaw);
 
   const workspace = String(parsed.workspace || parsed.repo || process.cwd());
   const memoryPath = parsed.memoryPath || `${workspace}/.openclaw/agent.memory.jsonl`;

--- a/packages/agent/test/config.test.ts
+++ b/packages/agent/test/config.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadAgentConfig } from "../src/config.js";
+
+describe("agent config env interpolation", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "tps-agent-config-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.AGENT_WORKSPACE;
+    delete process.env.AGENT_NAME;
+  });
+
+  test("resolves ${VAR_NAME} placeholders in string values", () => {
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    process.env.AGENT_WORKSPACE = "/tmp/ws";
+    process.env.AGENT_NAME = "Coder";
+
+    const cfg = join(dir, "agent.yaml");
+    writeFileSync(
+      cfg,
+      [
+        "agentId: coder",
+        "name: ${AGENT_NAME}",
+        "workspace: ${AGENT_WORKSPACE}",
+        "mailDir: ${AGENT_WORKSPACE}/mail",
+        "llm:",
+        "  provider: anthropic",
+        "  model: claude-sonnet-4-6",
+        "  apiKey: ${ANTHROPIC_API_KEY}",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const parsed = loadAgentConfig(cfg);
+    expect(parsed.name).toBe("Coder");
+    expect(parsed.workspace).toBe("/tmp/ws");
+    expect(parsed.mailDir).toBe("/tmp/ws/mail");
+    expect(parsed.llm.apiKey).toBe("test-key");
+  });
+
+  test("throws when referenced env var is missing", () => {
+    const cfg = join(dir, "agent-missing.yaml");
+    writeFileSync(
+      cfg,
+      [
+        "agentId: coder",
+        "name: Coder",
+        "workspace: /tmp/ws",
+        "llm:",
+        "  provider: anthropic",
+        "  model: claude-sonnet-4-6",
+        "  apiKey: ${MISSING_API_KEY}",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    expect(() => loadAgentConfig(cfg)).toThrow("Missing environment variable: MISSING_API_KEY");
+  });
+});


### PR DESCRIPTION
Implements CP33B part 2 (Credential injection via environment variables):

- `packages/agent/src/config.ts` now resolves `${VAR_NAME}` placeholders in all string values before config parsing/normalization.
- Missing env vars now fail fast with clear error (`Missing environment variable: <VAR>`).
- Added tests in `packages/agent/test/config.test.ts` for:
  - successful interpolation
  - missing env var error path

Validation:
- `cd packages/agent && bun run build`
- `cd packages/agent && bun test` (24 pass, 0 fail)
