### PR TITLE
chore: v0.5.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update && apt-get install -y libdbus-1-dev pkg-config
 RUN git clone --depth 1 https://github.com/lukehinds/nono.git /tmp/nono && cd /tmp/nono && cargo build --release
 
 FROM node:24-bookworm-slim AS base
-ARG TPS_VERSION=0.5.1
+ARG TPS_VERSION=0.5.2
 RUN npm install -g @tpsdev-ai/agent@${TPS_VERSION}
 COPY --from=nono-builder /tmp/nono/target/release/nono /usr/local/bin/nono
 RUN apt-get update && apt-get install -y --no-install-recommends git curl jq ca-certificates libdbus-1-3 && rm -rf /var/lib/apt/lists/*

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/agent",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Native TPS Agent Runtime — headless, mail-driven, nono-sandboxed",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-darwin-arm64",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TPS CLI native binary for darwin-arm64",
   "os": [
     "darwin"

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-darwin-x64",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TPS CLI native binary for darwin-x64",
   "os": [
     "darwin"

--- a/packages/cli-linux-arm64/package.json
+++ b/packages/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-linux-arm64",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TPS CLI native binary for linux-arm64",
   "os": [
     "linux"

--- a/packages/cli-linux-x64/package.json
+++ b/packages/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/cli-linux-x64",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TPS CLI native binary for linux-x64",
   "os": [
     "linux"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@tpsdev-ai/cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TPS Report CLI — because every agent needs the proper paperwork.",
   "type": "module",
   "bin": {
     "tps": "./bin/tps.cjs"
   },
   "optionalDependencies": {
-    "@tpsdev-ai/cli-darwin-arm64": "0.5.1",
-    "@tpsdev-ai/cli-darwin-x64": "0.5.1",
-    "@tpsdev-ai/cli-linux-arm64": "0.5.1",
-    "@tpsdev-ai/cli-linux-x64": "0.5.1"
+    "@tpsdev-ai/cli-darwin-arm64": "0.5.2",
+    "@tpsdev-ai/cli-darwin-x64": "0.5.2",
+    "@tpsdev-ai/cli-linux-arm64": "0.5.2",
+    "@tpsdev-ai/cli-linux-x64": "0.5.2"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Version bump. Triggers npm publish + first ghcr.io Docker image build.