### PR TITLE
fix: allow su in nono sandbox + remove premature proxy/secrets paths

### DIFF
--- a/docker/tps-office-supervisor.sh
+++ b/docker/tps-office-supervisor.sh
@@ -73,8 +73,7 @@ for ((i=0; i<count; i++)); do
   nono run \
     --allow "$workdir" \
     --allow "$tmpdir" \
-    --allow /var/run/tps-proxy.sock \
-    --allow /run/secrets \
+    --allow-command su \
     -- su -s /bin/bash "$user" -c "tps-agent start --config '$config_path'" &
 
   pid=$!


### PR DESCRIPTION
Found during e2e testing:

- nono blocks `su` by default — added `--allow-command su` so supervisor can drop privileges to per-agent users
- Removed `--allow /var/run/tps-proxy.sock` and `--allow /run/secrets` (not implemented yet, was causing warnings)

**E2E test results** (manual, inside container):
- ✅ Supervisor creates per-agent Linux users
- ✅ nono Landlock sandbox active (per-agent workspace isolation)
- ✅ tps-agent starts, writes PID file, creates mail directories
- ✅ Agent runs as daemon waiting for mail/events

**Known issue**: Landlock + Docker Desktop volume mounts don't work (EACCES on bind-mounted files). Native filesystem inside container works fine. This means agent configs/workspaces need to be inside the container, not volume-mounted from macOS host. Linux hosts should work with volume mounts.