### PR TITLE
fix: office start + Docker workflow race condition

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,9 @@
 name: Docker Image
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -18,6 +18,7 @@ jobs:
   build-and-push:
     name: Build & Push
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -25,7 +26,6 @@ jobs:
         id: version
         env:
           INPUT_VERSION: ${{ inputs.version }}
-          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ -n "$INPUT_VERSION" ]; then
             # Validate: must be semver-like (digits and dots only)
@@ -35,7 +35,8 @@ jobs:
             echo "tps_version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
             echo "tag=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
           else
-            V="${REF_NAME#v}"
+            # Read version from package.json (workflow_run trigger)
+            V=$(node -p "require('./packages/cli/package.json').version")
             echo "tps_version=$V" >> "$GITHUB_OUTPUT"
             echo "tag=$V" >> "$GITHUB_OUTPUT"
           fi

--- a/packages/cli/src/commands/office.ts
+++ b/packages/cli/src/commands/office.ts
@@ -162,9 +162,9 @@ function parseManifestMountArgs(manifestPath?: string): string[] {
 }
 
 function dockerImageFromManifest(manifestPath?: string): string {
-  if (!manifestPath) return "tps-office:latest";
+  if (!manifestPath) return "ghcr.io/tpsdev-ai/tps-office:latest";
   const manifest = parseOfficeManifest(manifestPath);
-  return (manifest as any).image || "tps-office:latest";
+  return (manifest as any).image || "ghcr.io/tpsdev-ai/tps-office:latest";
 }
 
 export function parseJoinToken(tokenUrl: string): any {
@@ -267,7 +267,7 @@ export async function runOffice(args: OfficeArgs): Promise<void> {
       const mountArgs = parseManifestMountArgs(manifest);
       const workspaceMount = isTeam ? join(branchRoot(), teamId) : ws;
       mountArgs.push("-v", `${workspaceMount}:/workspace`);
-      mountArgs.push("-v", `${join(ws, "mail")}:/mail`);
+      // Mail dirs are inside each agent workspace — no separate /mail mount needed
       mountArgs.push("--mount", "type=tmpfs,destination=/run/secrets");
 
       const existing = findContainer(agent);
@@ -304,8 +304,21 @@ export async function runOffice(args: OfficeArgs): Promise<void> {
         )
       );
 
+      // Pass through known API key env vars to the container
+      const envPassthrough: string[] = [];
+      const API_KEY_VARS = [
+        "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY",
+        "GEMINI_API_KEY", "OLLAMA_HOST",
+      ];
+      for (const key of API_KEY_VARS) {
+        if (process.env[key]) {
+          envPassthrough.push("-e", `${key}=${process.env[key]}`);
+        }
+      }
+
       const createResult = spawnSync("docker", [
         "run", "-d", "--name", sName,
+        ...envPassthrough,
         ...mountArgs,
         image,
       ], { stdio: "inherit", encoding: "utf-8", timeout: 120_000 });


### PR DESCRIPTION
Three fixes from e2e testing:

**office.ts:**
- Default Docker image → `ghcr.io/tpsdev-ai/tps-office:latest` (was local `tps-office:latest`)
- Pass API key env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `OLLAMA_HOST`) to container
- Remove separate `/mail` volume mount — mail dirs live inside agent workspaces

**docker.yml:**
- Trigger on Release workflow completion instead of tag push (fixes race where Docker tried `npm install` before packages were published)
- Skip build on failed releases
- Read version from `package.json` for `workflow_run` trigger

367 tests pass.