### PR TITLE
fix: Ollama tool call parsing

### DIFF
--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -109,8 +109,10 @@ export class ProviderManager {
     if (message?.tool_calls) {
       toolCalls = message.tool_calls.map((toolCall: any) => ({
         id: toolCall?.id,
-        name: toolCall?.name,
-        input: this.safeJson(toolCall?.arguments),
+        name: toolCall?.function?.name,
+        input: typeof toolCall?.function?.arguments === "string"
+          ? this.safeJson(toolCall.function.arguments)
+          : toolCall?.function?.arguments ?? {},
       }));
     }
 


### PR DESCRIPTION
**Bug**: Ollama provider returned tool name as `undefined` — mapper was reading `toolCall.name` instead of `toolCall.function.name`.

**Fix**: Align Ollama response mapper with actual API format (`function.name`, `function.arguments`). Also handles Ollama returning arguments as objects (not JSON strings like OpenAI).

**Tested**: Real e2e with qwen3:8b on Ollama. Agent receives task → calls `write` tool → creates file → confirms success.

367 tests pass.