### PR TITLE
CI: add compiled binary smoke gate before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,37 @@ jobs:
           path: /tmp/release/${{ matrix.pkg }}
           if-no-files-found: error
 
+  smoke-compiled-binary:
+    name: Smoke compiled binary
+    needs: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+      - run: bun install --frozen-lockfile
+      - name: Build linux-x64 release binary
+        run: |
+          bun build --compile ./packages/cli/bin/tps.ts             --target=bun-linux-x64             --outfile=/tmp/tps-release-smoke
+          chmod +x /tmp/tps-release-smoke
+      - name: Smoke test --version
+        run: |
+          VERSION_OUTPUT=$(/tmp/tps-release-smoke --version)
+          PKG_VERSION=$(node -p "require('./packages/cli/package.json').version")
+          if [ "$VERSION_OUTPUT" != "$PKG_VERSION" ]; then
+            echo "❌ version mismatch: binary=$VERSION_OUTPUT package=$PKG_VERSION"
+            exit 1
+          fi
+      - name: Smoke test office list
+        run: |
+          export HOME=$(mktemp -d)
+          mkdir -p "$HOME/.tps/branch-office"
+          TPS_OFFICE_SKIP_VM=1 /tmp/tps-release-smoke office list >/tmp/tps-office-list.log 2>&1
+
   publish-packages:
     name: Publish npm packages
-    needs: build-binaries
+    needs: [build-binaries, smoke-compiled-binary]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Adds a release guardrail to catch compiler/runtime drift before publishing packages.

What this adds:
- New `smoke-compiled-binary` job in `.github/workflows/release.yml`
- Builds compiled linux-x64 binary in release workflow
- Verifies `tps --version` matches `packages/cli/package.json`
- Runs `tps office list` smoke check with `TPS_OFFICE_SKIP_VM=1`
- Makes `publish-packages` depend on both `build-binaries` and this smoke job

This prevents a repeat of Bun/compiler drift where published binary behavior diverges from source CI.
