### PR TITLE
chore: add CODEOWNERS — Sherlock + Nathan required reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Require review from Sherlock (security) and Nathan (owner) on all changes.
 # Sherlock's approval is required before Flint can merge.
-* @sherlock-tps @squeued
+* @sherlock-tps @heskew


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so all PRs require review from @sherlock-tps and @squeued before merge.

Part of branch protection setup (ops-27.2).