### PR TITLE
chore: CODEOWNERS → team-based review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-# Require review from Sherlock (security) and Nathan (owner) on all changes.
-# Sherlock's approval is required before Flint can merge.
-* @sherlock-tps @heskew
+# Require review from any member of the reviewers team.
+# Currently: heskew (Nathan) and tps-sherlock (Sherlock).
+# One approval from either satisfies branch protection.
+* @tpsdev-ai/reviewers


### PR DESCRIPTION
Switches from individual code owners (@sherlock-tps + @heskew) to team-based (@tpsdev-ai/reviewers). One approval from any team member now satisfies branch protection.