### PR TITLE
hardening: enforce office secret-ready lifecycle

### DIFF
--- a/docker/tps-office-supervisor.sh
+++ b/docker/tps-office-supervisor.sh
@@ -17,10 +17,15 @@ mkdir -p /workspace/.tps
 SECRETS_DIR="/run/secrets"
 SECRETS_TIMEOUT=30
 elapsed=0
-while [[ ! -f "$SECRETS_DIR/.ready" ]] && [[ $elapsed -lt $SECRETS_TIMEOUT ]]; do
+while [[ ! -f "$SECRETS_DIR/.ready" ]] && [[ $elapsed -lt $((SECRETS_TIMEOUT * 2)) ]]; do
   sleep 0.5
   elapsed=$((elapsed + 1))
 done
+
+if [[ ! -f "$SECRETS_DIR/.ready" ]]; then
+  echo "Timed out waiting for $SECRETS_DIR/.ready" >&2
+  exit 1
+fi
 
 # Load secrets into environment, then unlink all files.
 # After this, secrets exist only in this process's memory.

--- a/packages/cli/src/commands/office.ts
+++ b/packages/cli/src/commands/office.ts
@@ -337,15 +337,14 @@ export async function runOffice(args: OfficeArgs): Promise<void> {
 
       // S33B-E: Inject secrets into tmpfs after container start.
       // Supervisor waits for /run/secrets/.ready before booting agents.
+      // Always mark .ready (even with zero secrets) so startup is deterministic.
       // Secrets piped via stdin — never appear in process args or logs.
-      if (secretsToInject.length > 0) {
-        try {
-          injectSecrets(sName, secretsToInject);
-        } catch (e: any) {
-          console.error(`Secret injection failed: ${e?.message || e}`);
-          try { spawnSync("docker", ["rm", "-f", sName], { stdio: "pipe", encoding: "utf-8" }); } catch {}
-          process.exit(1);
-        }
+      try {
+        injectSecrets(sName, secretsToInject);
+      } catch (e: any) {
+        console.error(`Secret injection failed: ${e?.message || e}`);
+        try { spawnSync("docker", ["rm", "-f", sName], { stdio: "pipe", encoding: "utf-8" }); } catch {}
+        process.exit(1);
       }
 
       if (manifest && loadWorkspaceManifest(ws)) {


### PR DESCRIPTION
## Summary
- make supervisor fail if `/run/secrets/.ready` is not present before timeout
- correct timeout loop to actually wait 30s at 0.5s intervals
- always mark `/run/secrets/.ready` from host path, even when zero secrets are injected

## Why
- deterministic startup lifecycle for supervisor/agents
- fail-closed behavior if secret handoff phase does not complete

## Validation
- `bash -n docker/tps-office-supervisor.sh`
- `bun test packages/cli/test/office.test.ts`