### PR TITLE
fix: bridge PID path mismatch

### DIFF
--- a/packages/cli/src/commands/bridge.ts
+++ b/packages/cli/src/commands/bridge.ts
@@ -8,11 +8,9 @@
  */
 
 import { bridgeStatus, startBridgeDaemon } from "../utils/mail-bridge.js";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-
-const BRIDGE_PID_PATH = join(homedir(), ".tps", "run", "mail-bridge.pid");
 
 export interface BridgeArgs {
   action: "start" | "stop" | "status";
@@ -45,17 +43,19 @@ export async function runBridge(args: BridgeArgs): Promise<void> {
     }
 
     case "stop": {
-      if (!existsSync(BRIDGE_PID_PATH)) {
+      const st = bridgeStatus();
+      if (!st.running) {
         console.log("Bridge is not running.");
         break;
       }
       try {
-        const raw = JSON.parse(readFileSync(BRIDGE_PID_PATH, "utf-8"));
-        process.kill(raw.pid, "SIGTERM");
-        rmSync(BRIDGE_PID_PATH, { force: true });
-        console.log(`Bridge (pid ${raw.pid}) stopped.`);
+        process.kill(st.pid!, "SIGTERM");
+        // Clean up PID file (try both old and new paths)
+        const pidDir = join(homedir(), ".tps", "run");
+        rmSync(join(pidDir, "bridge-openclaw.pid"), { force: true });
+        rmSync(join(pidDir, "mail-bridge.pid"), { force: true });
+        console.log(`Bridge (pid ${st.pid}) stopped.`);
       } catch {
-        rmSync(BRIDGE_PID_PATH, { force: true });
         console.log("Bridge was not running (stale pid cleaned up).");
       }
       break;

--- a/packages/cli/src/utils/mail-bridge.ts
+++ b/packages/cli/src/utils/mail-bridge.ts
@@ -27,15 +27,21 @@ export function bridgeStatus(): { running: boolean; pid?: number; port?: number 
   const { existsSync, readFileSync } = require("node:fs");
   const { homedir } = require("node:os");
   const { join } = require("node:path");
-  const pidPath = join(homedir(), ".tps", "run", "bridge-openclaw.pid");
-  if (!existsSync(pidPath)) return { running: false };
-  try {
-    const raw = JSON.parse(readFileSync(pidPath, "utf-8"));
-    process.kill(raw.pid, 0);
-    return { running: true, pid: raw.pid, port: raw.port };
-  } catch {
-    return { running: false };
+  const home = process.env.HOME ?? homedir();
+  const pidDir = join(home, ".tps", "run");
+  // Check both new and legacy PID paths
+  for (const name of ["bridge-openclaw.pid", "mail-bridge.pid"]) {
+    const pidPath = join(pidDir, name);
+    if (!existsSync(pidPath)) continue;
+    try {
+      const raw = JSON.parse(readFileSync(pidPath, "utf-8"));
+      process.kill(raw.pid, 0);
+      return { running: true, pid: raw.pid, port: raw.port };
+    } catch {
+      continue;
+    }
   }
+  return { running: false };
 }
 
 export function startBridgeDaemon(config: BridgeConfig = {}): void {


### PR DESCRIPTION
Kern caught this in #65 review: `commands/bridge.ts` was looking for `mail-bridge.pid` but `BridgeCore` writes `bridge-openclaw.pid`. `tps bridge stop` would fail to find the process.

Fix: `bridgeStatus()` checks both paths, stop command uses `bridgeStatus()` instead of hardcoded path. 469/469 tests pass.