### PR TITLE
feat(ops-31.2): tps memory reflect + consolidate

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -513,6 +513,43 @@ async function main() {
       }
       break;
     }
+    case "memory": {
+      // ops-31.2: reflect + consolidate (ops-31.1 governance commands come with PR #67)
+      const action = rest[0] as "reflect" | "consolidate" | undefined;
+      if (!action || !["reflect", "consolidate"].includes(action)) {
+        console.error(
+          "Usage:\n" +
+          "  tps memory reflect <agentId> [--scope recent|tagged|all] [--since ISO] [--focus lessons_learned|patterns|decisions|errors] [--limit N]\n" +
+          "  tps memory consolidate <agentId> [--scope persistent|standard|all] [--older-than 30d] [--limit N]"
+        );
+        process.exit(1);
+      }
+
+      const agentId = rest[1];
+      if (!agentId) { console.error(`Usage: tps memory ${action} <agentId>`); process.exit(1); }
+
+      const getFlag = (name: string): string | undefined => {
+        const idx = process.argv.indexOf(`--${name}`);
+        return idx >= 0 ? process.argv[idx + 1] : undefined;
+      };
+
+      const { runMemoryLearn } = await import("../src/commands/memory-learn.js");
+      await runMemoryLearn({
+        action,
+        agentId,
+        scope: getFlag("scope"),
+        since: getFlag("since"),
+        focus: getFlag("focus"),
+        tag: getFlag("tag"),
+        olderThan: getFlag("older-than"),
+        durabilityScope: getFlag("scope"),
+        limit: getFlag("limit") ? parseInt(getFlag("limit")!, 10) : undefined,
+        flairUrl: getFlag("flair-url") ?? process.env.FLAIR_URL,
+        json: cli.flags.json,
+      });
+      break;
+    }
+
     case "proxy": {
       const subAction = rest[0] as "start" | "stop" | "status" | undefined;
       if (!subAction || !["start", "stop", "status"].includes(subAction)) {

--- a/packages/cli/src/commands/memory-learn.ts
+++ b/packages/cli/src/commands/memory-learn.ts
@@ -1,0 +1,96 @@
+/**
+ * tps memory reflect | consolidate
+ *
+ * Learning pipeline commands — ops-31.2.
+ * These extend tps memory (ops-31.1) with reflection and consolidation.
+ *
+ * reflect <agentId>    — gather memories, build LLM reflection prompt
+ * consolidate <agentId> — review persistent memories for promote/archive/keep
+ */
+
+import { createFlairClient } from "../utils/flair-client.js";
+
+export interface MemoryLearnArgs {
+  action: "reflect" | "consolidate";
+  agentId: string;
+  // reflect
+  scope?: string;
+  since?: string;
+  focus?: string;
+  tag?: string;
+  limit?: number;
+  // consolidate
+  olderThan?: string;
+  durabilityScope?: string;
+  // shared
+  flairUrl?: string;
+  json?: boolean;
+  keyPath?: string;
+}
+
+export async function runMemoryLearn(args: MemoryLearnArgs): Promise<void> {
+  const flairUrl = args.flairUrl ?? process.env.FLAIR_URL ?? "http://127.0.0.1:9926";
+  const flair = createFlairClient(args.agentId, flairUrl, args.keyPath);
+
+  switch (args.action) {
+    case "reflect": {
+      const result = await flair.reflectMemory({
+        agentId: args.agentId,
+        scope: (args.scope as any) ?? "recent",
+        since: args.since,
+        maxMemories: args.limit,
+        focus: (args.focus as any) ?? "lessons_learned",
+        tag: args.tag,
+      });
+
+      if (args.json) {
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+
+      console.log(`\n${result.prompt}\n`);
+      console.log(`─── ${result.count} source memories ────────────────────────────`);
+      for (const m of result.memories) {
+        const date = m.createdAt?.slice(0, 10) ?? "?";
+        const tags = m.tags?.length ? ` [${m.tags.join(", ")}]` : "";
+        console.log(`  ${m.id} (${date})${tags}`);
+        console.log(`    ${m.content.slice(0, 120)}`);
+      }
+      if (result.suggestedTags.length) {
+        console.log(`\nSuggested tags: ${result.suggestedTags.join(", ")}`);
+      }
+      break;
+    }
+
+    case "consolidate": {
+      const result = await flair.consolidateMemory({
+        agentId: args.agentId,
+        scope: (args.durabilityScope as any) ?? "persistent",
+        olderThan: args.olderThan,
+        limit: args.limit,
+      });
+
+      if (args.json) {
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+
+      console.log(`\n${result.prompt}\n`);
+      console.log(`─── ${result.candidates.length} candidates ───────────────────────`);
+      for (const c of result.candidates) {
+        const badge = c.suggestion === "promote" ? "⬆" : c.suggestion === "archive" ? "🗄" : "•";
+        const date = c.memory.createdAt?.slice(0, 10) ?? "?";
+        console.log(`\n${badge} ${c.suggestion.toUpperCase()} — ${c.memory.id} (${date}, ${c.memory.durability})`);
+        console.log(`  Reason: ${c.reason}`);
+        console.log(`  ${c.memory.content.slice(0, 120)}`);
+      }
+      break;
+    }
+
+    default: {
+      const _: never = args.action;
+      console.error(`Unknown action: ${_}`);
+      process.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/utils/flair-client.ts
+++ b/packages/cli/src/utils/flair-client.ts
@@ -41,6 +41,24 @@ export interface SearchResult {
   type?: string;
 }
 
+export interface ReflectResult {
+  memories: Memory[];
+  prompt: string;
+  suggestedTags: string[];
+  count: number;
+}
+
+export interface ConsolidateCandidate {
+  memory: Memory;
+  suggestion: "promote" | "archive" | "keep";
+  reason: string;
+}
+
+export interface ConsolidateResult {
+  candidates: ConsolidateCandidate[];
+  prompt: string;
+}
+
 export interface FlairAgent {
   id: string;
   name: string;
@@ -258,6 +276,40 @@ export class FlairClient {
     return sections.join("") || "(No Flair context available)";
   }
 
+  // ─── Learning pipeline (ops-31.2) ───────────────────────────────────────────
+
+  async reflectMemory(opts: {
+    agentId?: string;
+    scope?: "recent" | "tagged" | "all";
+    since?: string;
+    maxMemories?: number;
+    focus?: "lessons_learned" | "patterns" | "decisions" | "errors";
+    tag?: string;
+  } = {}): Promise<ReflectResult> {
+    return this.request<ReflectResult>("POST", "/MemoryReflect/", {
+      agentId: opts.agentId ?? this.agentId,
+      scope: opts.scope ?? "recent",
+      since: opts.since,
+      maxMemories: opts.maxMemories ?? 50,
+      focus: opts.focus ?? "lessons_learned",
+      tag: opts.tag,
+    });
+  }
+
+  async consolidateMemory(opts: {
+    agentId?: string;
+    scope?: "persistent" | "standard" | "all";
+    olderThan?: string;
+    limit?: number;
+  } = {}): Promise<ConsolidateResult> {
+    return this.request<ConsolidateResult>("POST", "/MemoryConsolidate/", {
+      agentId: opts.agentId ?? this.agentId,
+      scope: opts.scope ?? "persistent",
+      olderThan: opts.olderThan ?? "30d",
+      limit: opts.limit ?? 20,
+    });
+  }
+
   async ping(): Promise<boolean> {
     try {
       const res = await fetch(`${this.baseUrl}/Health`);
@@ -271,9 +323,11 @@ export class FlairClient {
 export function createFlairClient(
   agentId: string,
   baseUrl?: string,
+  keyPath?: string,
 ): FlairClient {
   return new FlairClient({
     agentId,
     baseUrl: baseUrl ?? process.env.FLAIR_URL ?? "http://127.0.0.1:9926",
+    keyPath,
   });
 }

--- a/packages/cli/test/memory-learn.test.ts
+++ b/packages/cli/test/memory-learn.test.ts
@@ -1,0 +1,169 @@
+/**
+ * ops-31.2 — tps memory reflect + consolidate CLI tests
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { writeFileSync, unlinkSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let _savedFetch: typeof globalThis.fetch;
+const TEST_KEY_PATH = join(tmpdir(), `tps-test-learn-${process.pid}.pem`);
+
+beforeAll(() => {
+  _savedFetch = globalThis.fetch;
+  const { privateKey } = generateKeyPairSync("ed25519", {
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  writeFileSync(TEST_KEY_PATH, privateKey, { mode: 0o600 });
+});
+
+afterAll(() => {
+  globalThis.fetch = _savedFetch;
+  if (existsSync(TEST_KEY_PATH)) unlinkSync(TEST_KEY_PATH);
+});
+
+const REFLECT_RESPONSE = {
+  memories: [
+    { id: "m1", agentId: "flint", content: "Never use bare gh commands", createdAt: "2026-03-01T10:00:00Z", durability: "standard", tags: ["git", "ci"] },
+    { id: "m2", agentId: "flint", content: "PR conflicts happen when reviewers push to author branches", createdAt: "2026-03-01T12:00:00Z", durability: "standard", tags: ["git"] },
+  ],
+  prompt: "# Memory Reflection — flint\nFocus: lessons_learned\n...",
+  suggestedTags: ["git", "ci"],
+  count: 2,
+};
+
+const CONSOLIDATE_RESPONSE = {
+  candidates: [
+    { memory: { id: "m3", agentId: "flint", content: "Ed25519 everywhere", durability: "persistent", createdAt: "2026-01-01T00:00:00Z", retrievalCount: 8 }, suggestion: "promote", reason: "Retrieved 8 times — strong promotion candidate" },
+    { memory: { id: "m4", agentId: "flint", content: "Old transport decision", durability: "persistent", createdAt: "2025-12-01T00:00:00Z", retrievalCount: 0 }, suggestion: "archive", reason: "Never retrieved, 90 days old" },
+  ],
+  prompt: "# Memory Consolidation Review — flint\n...",
+};
+
+describe("ops-31.2: tps memory reflect", () => {
+  test("calls MemoryReflect and prints prompt + memories", async () => {
+    let capturedBody: any;
+    globalThis.fetch = (async (url: string, opts?: RequestInit) => {
+      if (String(url).includes("/MemoryReflect")) {
+        capturedBody = JSON.parse(opts?.body as string);
+        return new Response(JSON.stringify(REFLECT_RESPONSE), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as any;
+
+    const { runMemoryLearn } = await import("../src/commands/memory-learn.js");
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: any[]) => lines.push(a.join(" "));
+
+    await runMemoryLearn({ action: "reflect", agentId: "flint", flairUrl: "http://127.0.0.1:19926", keyPath: TEST_KEY_PATH });
+    console.log = origLog;
+
+    expect(capturedBody.agentId).toBe("flint");
+    expect(capturedBody.focus).toBe("lessons_learned");
+    const output = lines.join("\n");
+    expect(output).toContain("Memory Reflection");
+    expect(output).toContain("m1");
+    expect(output).toContain("m2");
+  });
+
+  test("--focus flag is forwarded", async () => {
+    let capturedBody: any;
+    globalThis.fetch = (async (url: string, opts?: RequestInit) => {
+      if (String(url).includes("/MemoryReflect")) {
+        capturedBody = JSON.parse(opts?.body as string);
+        return new Response(JSON.stringify({ ...REFLECT_RESPONSE, count: 0, memories: [] }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as any;
+
+    const { runMemoryLearn } = await import("../src/commands/memory-learn.js");
+    await runMemoryLearn({ action: "reflect", agentId: "flint", focus: "patterns", flairUrl: "http://127.0.0.1:19926", keyPath: TEST_KEY_PATH });
+
+    expect(capturedBody.focus).toBe("patterns");
+  });
+
+  test("--json outputs valid JSON", async () => {
+    globalThis.fetch = (async (url: string) => {
+      if (String(url).includes("/MemoryReflect")) return new Response(JSON.stringify(REFLECT_RESPONSE), { status: 200 });
+      return new Response("{}", { status: 200 });
+    }) as any;
+
+    const { runMemoryLearn } = await import("../src/commands/memory-learn.js");
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: any[]) => lines.push(a.join(" "));
+
+    await runMemoryLearn({ action: "reflect", agentId: "flint", json: true, flairUrl: "http://127.0.0.1:19926", keyPath: TEST_KEY_PATH });
+    console.log = origLog;
+
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.count).toBe(2);
+    expect(Array.isArray(parsed.memories)).toBe(true);
+  });
+});
+
+describe("ops-31.2: tps memory consolidate", () => {
+  test("calls MemoryConsolidate and prints candidates", async () => {
+    let capturedBody: any;
+    globalThis.fetch = (async (url: string, opts?: RequestInit) => {
+      if (String(url).includes("/MemoryConsolidate")) {
+        capturedBody = JSON.parse(opts?.body as string);
+        return new Response(JSON.stringify(CONSOLIDATE_RESPONSE), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as any;
+
+    const { runMemoryLearn } = await import("../src/commands/memory-learn.js");
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: any[]) => lines.push(a.join(" "));
+
+    await runMemoryLearn({ action: "consolidate", agentId: "flint", flairUrl: "http://127.0.0.1:19926", keyPath: TEST_KEY_PATH });
+    console.log = origLog;
+
+    expect(capturedBody.agentId).toBe("flint");
+    expect(capturedBody.scope).toBe("persistent");
+    const output = lines.join("\n");
+    expect(output).toContain("PROMOTE");
+    expect(output).toContain("ARCHIVE");
+    expect(output).toContain("m3");
+    expect(output).toContain("m4");
+  });
+
+  test("--older-than forwarded to API", async () => {
+    let capturedBody: any;
+    globalThis.fetch = (async (url: string, opts?: RequestInit) => {
+      if (String(url).includes("/MemoryConsolidate")) {
+        capturedBody = JSON.parse(opts?.body as string);
+        return new Response(JSON.stringify({ candidates: [], prompt: "" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as any;
+
+    const { runMemoryLearn } = await import("../src/commands/memory-learn.js");
+    await runMemoryLearn({ action: "consolidate", agentId: "flint", olderThan: "7d", flairUrl: "http://127.0.0.1:19926", keyPath: TEST_KEY_PATH });
+
+    expect(capturedBody.olderThan).toBe("7d");
+  });
+
+  test("--json outputs valid JSON", async () => {
+    globalThis.fetch = (async (url: string) => {
+      if (String(url).includes("/MemoryConsolidate")) return new Response(JSON.stringify(CONSOLIDATE_RESPONSE), { status: 200 });
+      return new Response("{}", { status: 200 });
+    }) as any;
+
+    const { runMemoryLearn } = await import("../src/commands/memory-learn.js");
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: any[]) => lines.push(a.join(" "));
+
+    await runMemoryLearn({ action: "consolidate", agentId: "flint", json: true, flairUrl: "http://127.0.0.1:19926", keyPath: TEST_KEY_PATH });
+    console.log = origLog;
+
+    const parsed = JSON.parse(lines[0]);
+    expect(Array.isArray(parsed.candidates)).toBe(true);
+    expect(parsed.candidates[0].suggestion).toBe("promote");
+  });
+});


### PR DESCRIPTION
## ops-31.2 — Learning Pipeline: CLI

Human CLI for the MemoryReflect/MemoryConsolidate endpoints (companion to tpsdev-ai/flair#10).

### New commands

```
tps memory reflect <agentId>
  --scope   recent | tagged | all   (default: recent)
  --since   ISO timestamp           (default: 24h ago)
  --focus   lessons_learned | patterns | decisions | errors
  --limit   N                       (default: 50)
  --tag     <tag>                   (required for scope=tagged)

tps memory consolidate <agentId>
  --scope     persistent | standard | all   (default: persistent)
  --older-than  30d | 7d | ...              (default: 30d)
  --limit     N                             (default: 20)
```

### How it works

**reflect**: Calls `POST /MemoryReflect`, prints the structured LLM prompt + source memories. Agent feeds the prompt to its LLM, writes insights back as persistent memories with `derivedFrom` links.

**consolidate**: Calls `POST /MemoryConsolidate`, prints promote/archive/keep candidates with reasons. Feeds naturally into `tps memory approve` / `tps memory archive` (from ops-31.1 #67).

### Note on merge order
This branch is based on pre-#67 main. `memory-learn.ts` is a standalone module to avoid conflict with #67's `memory.ts`. After both PRs merge, the commands can be consolidated into a single `memory.ts` file.

### Tests
6 new tests — 401/401 pass.