### PR TITLE
feat(ops-31.3): tps agent create seeds Flair on creation

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -223,7 +223,7 @@ async function main() {
       if (!action || !validActions.includes(action)) {
         console.error(
           "Usage:\n" +
-          "  tps agent create --id <agent-id> [--name <name>] [--model <provider/model>]\n" +
+          "  tps agent create --id <agent-id> [--name <name>] [--model <provider/model>] [--display-name <name>] [--soul-file <path>] [--no-seed]\n" +
           "  tps agent list [--json]\n" +
           "  tps agent status --id <agent-id> [--json]\n" +
           "  tps agent run --id <agent-id> --message <text>\n" +
@@ -247,6 +247,9 @@ async function main() {
           name: getFlag("name"),
           model: getFlag("model"),
           flairUrl: getFlag("flair-url") ?? process.env.FLAIR_URL,
+          displayName: getFlag("display-name"),
+          soulFile: getFlag("soul-file"),
+          noSeed: process.argv.includes("--no-seed"),
         });
       } else if (action === "list") {
         await runAgent({ action: "list", json: cli.flags.json, flairUrl: getFlag("flair-url") });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -23,6 +23,10 @@ export interface AgentArgs {
   config?: string;
   message?: string;
   /** For create/list/status */
+  displayName?: string;
+  soulFile?: string;
+  noSeed?: boolean;
+  starterMemories?: Array<{ content: string; tags?: string[]; durability?: string }>;
   id?: string;
   name?: string;
   model?: string;
@@ -31,6 +35,19 @@ export interface AgentArgs {
 }
 
 // ─── create ──────────────────────────────────────────────────────────────────
+
+async function loadSoulFile(filePath: string): Promise<Record<string, string>> {
+  const { readFileSync } = await import("node:fs");
+  const raw = readFileSync(filePath, "utf8");
+  // Support simple KEY: value YAML or JSON
+  if (filePath.endsWith(".json")) return JSON.parse(raw);
+  const result: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const m = line.match(/^([\w-]+):\s*(.+)$/);
+    if (m) result[m[1]] = m[2].trim();
+  }
+  return result;
+}
 
 async function createAgent(args: AgentArgs): Promise<void> {
   const id = args.id;
@@ -76,17 +93,37 @@ async function createAgent(args: AgentArgs): Promise<void> {
     const existing = await flair.getAgent(id);
     if (existing) {
       console.log(`  Agent '${id}' already registered in Flair.`);
+      // Still register real public key if record has placeholder
+      if (existing.publicKey === "pending") {
+        await flair.updateAgent(id, { publicKey: pubKeyHex }).catch(() => {});
+      }
+    } else if (!args.noSeed) {
+      // Seed agent with soul + starter memories
+      const soulTemplate = args.soulFile
+        ? await loadSoulFile(args.soulFile)
+        : undefined;
+      const starterMemories = args.starterMemories;
+      try {
+        const seeded = await flair.seedAgent({
+          agentId: id,
+          displayName: name,
+          role: "agent",
+          soulTemplate,
+          starterMemories,
+        });
+        // Update the public key on the agent record that AgentSeed created
+        await flair.updateAgent(id, { publicKey: pubKeyHex }).catch(() => {});
+        console.log(`  Agent seeded: ${seeded.soulEntries.length} soul entries, ${seeded.memories.length} memories.`);
+      } catch (e: any) {
+        // AgentSeed requires admin auth — fall back to direct registration
+        await flair.registerAgent(name, pubKeyHex).catch(() => {});
+        console.log(`  Agent '${id}' registered in Flair (no seed — not admin).`);
+      }
     } else {
+      // --no-seed: just register
       await flair.registerAgent(name, pubKeyHex);
-      console.log(`  Agent '${id}' registered in Flair.`);
+      console.log(`  Agent '${id}' registered in Flair (seeding skipped).`);
     }
-
-    // Initialize soul
-    const soulKeys = { role: name, identity: `I am ${name}, a TPS agent.` };
-    for (const [k, v] of Object.entries(soulKeys)) {
-      await flair.setSoul(k, v).catch(() => {});
-    }
-    console.log(`  Soul initialized.`);
   }
 
   // 3. Write agent config

--- a/packages/cli/src/utils/flair-client.ts
+++ b/packages/cli/src/utils/flair-client.ts
@@ -310,6 +310,24 @@ export class FlairClient {
     });
   }
 
+  // ─── Onboarding seed (ops-31.3) ──────────────────────────────────────────────
+
+  async updateAgent(agentId: string, patch: Partial<FlairAgent>): Promise<void> {
+    const existing = await this.getAgent(agentId);
+    if (!existing) throw new Error(`Agent ${agentId} not found`);
+    await this.request("PUT", `/Agent/${agentId}`, { ...existing, ...patch });
+  }
+
+  async seedAgent(opts: {
+    agentId: string;
+    displayName?: string;
+    role?: "admin" | "agent";
+    soulTemplate?: Record<string, string>;
+    starterMemories?: Array<{ content: string; tags?: string[]; durability?: string }>;
+  }): Promise<{ agent: FlairAgent; soulEntries: any[]; memories: any[] }> {
+    return this.request("POST", "/AgentSeed/", opts);
+  }
+
   async ping(): Promise<boolean> {
     try {
       const res = await fetch(`${this.baseUrl}/Health`);

--- a/packages/cli/test/agent-seed.test.ts
+++ b/packages/cli/test/agent-seed.test.ts
@@ -1,0 +1,123 @@
+/**
+ * ops-31.3 — tps agent create onboarding seed tests
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { writeFileSync, unlinkSync, existsSync, mkdirSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+
+let _savedFetch: typeof globalThis.fetch;
+const TEST_AGENT_ID = `test-seed-agent-${process.pid}`;
+const TEST_IDENTITY_DIR = join(tmpdir(), `tps-test-identity-${process.pid}`);
+
+const SEED_RESPONSE = {
+  agent: { id: TEST_AGENT_ID, name: TEST_AGENT_ID, role: "agent", publicKey: "pending", createdAt: "2026-03-02T00:00:00Z", updatedAt: "2026-03-02T00:00:00Z" },
+  soulEntries: [
+    { id: `${TEST_AGENT_ID}:name`, agentId: TEST_AGENT_ID, key: "name", value: TEST_AGENT_ID },
+    { id: `${TEST_AGENT_ID}:role`, agentId: TEST_AGENT_ID, key: "role", value: "agent" },
+  ],
+  memories: [
+    { id: `seed-${TEST_AGENT_ID}-0`, agentId: TEST_AGENT_ID, content: `Agent ${TEST_AGENT_ID} initialized.`, durability: "persistent", tags: ["onboarding", "system"] },
+  ],
+};
+
+beforeAll(() => {
+  _savedFetch = globalThis.fetch;
+  mkdirSync(TEST_IDENTITY_DIR, { recursive: true });
+  // Pre-generate test Ed25519 key so createAgent doesn't try to write to real identity dir
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519", {
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  writeFileSync(join(TEST_IDENTITY_DIR, `${TEST_AGENT_ID}.key`), privateKey, { mode: 0o600 });
+  writeFileSync(join(TEST_IDENTITY_DIR, `${TEST_AGENT_ID}.pub`), publicKey);
+});
+
+afterAll(() => {
+  globalThis.fetch = _savedFetch;
+});
+
+describe("ops-31.3: FlairClient.seedAgent()", () => {
+  test("sends correct payload to /AgentSeed", async () => {
+    let capturedBody: any;
+    globalThis.fetch = (async (url: string, opts?: RequestInit) => {
+      if (String(url).includes("/AgentSeed")) {
+        capturedBody = JSON.parse(opts?.body as string);
+        return new Response(JSON.stringify(SEED_RESPONSE), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as any;
+
+    const { createFlairClient } = await import("../src/utils/flair-client.js");
+    const { generateKeyPairSync: gkp } = await import("node:crypto");
+    const { writeFileSync: wf } = await import("node:fs");
+    const adminKey = join(tmpdir(), `admin-${process.pid}.pem`);
+    wf(adminKey, gkp("ed25519", { privateKeyEncoding: { type: "pkcs8", format: "pem" } }).privateKey, { mode: 0o600 });
+    const flair = createFlairClient("admin", "http://127.0.0.1:19926", adminKey);
+    const result = await flair.seedAgent({
+      agentId: TEST_AGENT_ID,
+      displayName: "Test Agent",
+      role: "agent",
+      soulTemplate: { name: "Test Agent", team: "test" },
+    });
+
+    expect(capturedBody.agentId).toBe(TEST_AGENT_ID);
+    expect(capturedBody.displayName).toBe("Test Agent");
+    expect(capturedBody.soulTemplate.team).toBe("test");
+    expect(result.soulEntries.length).toBe(2);
+    expect(result.memories.length).toBe(1);
+  });
+
+  test("passes starterMemories to /AgentSeed", async () => {
+    let capturedBody: any;
+    globalThis.fetch = (async (url: string, opts?: RequestInit) => {
+      if (String(url).includes("/AgentSeed")) {
+        capturedBody = JSON.parse(opts?.body as string);
+        return new Response(JSON.stringify(SEED_RESPONSE), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as any;
+
+    const { createFlairClient } = await import("../src/utils/flair-client.js");
+    const { generateKeyPairSync: gkp2 } = await import("node:crypto");
+    const { writeFileSync: wf2 } = await import("node:fs");
+    const adminKey2 = join(tmpdir(), `admin2-${process.pid}.pem`);
+    wf2(adminKey2, gkp2("ed25519", { privateKeyEncoding: { type: "pkcs8", format: "pem" } }).privateKey, { mode: 0o600 });
+    const flair = createFlairClient("admin", "http://127.0.0.1:19926", adminKey2);
+    await flair.seedAgent({
+      agentId: TEST_AGENT_ID,
+      starterMemories: [{ content: "Custom memory", tags: ["test"], durability: "persistent" }],
+    });
+
+    expect(capturedBody.starterMemories).toHaveLength(1);
+    expect(capturedBody.starterMemories[0].content).toBe("Custom memory");
+  });
+});
+
+describe("ops-31.3: updateAgent()", () => {
+  test("read-modify-write: fetches existing record then PUTs merged", async () => {
+    const existing = { id: TEST_AGENT_ID, name: "old", role: "agent", publicKey: "pending", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" };
+    let putBody: any;
+    globalThis.fetch = (async (url: string, opts?: RequestInit) => {
+      if (String(url).includes("/Agent/")) {
+        if (opts?.method === "PUT") { putBody = JSON.parse(opts.body as string); return new Response("{}", { status: 200 }); }
+        return new Response(JSON.stringify(existing), { status: 200 });
+      }
+      if (opts?.method === "POST") return new Response(JSON.stringify([existing]), { status: 200 });
+      return new Response("{}", { status: 200 });
+    }) as any;
+
+    const { createFlairClient } = await import("../src/utils/flair-client.js");
+    const { generateKeyPairSync: gkp3 } = await import("node:crypto");
+    const { writeFileSync: wf3 } = await import("node:fs");
+    const adminKey3 = join(tmpdir(), `admin3-${process.pid}.pem`);
+    wf3(adminKey3, gkp3("ed25519", { privateKeyEncoding: { type: "pkcs8", format: "pem" } }).privateKey, { mode: 0o600 });
+    const flair = createFlairClient(TEST_AGENT_ID, "http://127.0.0.1:19926", adminKey3);
+    await flair.updateAgent(TEST_AGENT_ID, { publicKey: "newhex" });
+
+    expect(putBody.publicKey).toBe("newhex");
+    expect(putBody.name).toBe("old"); // preserved
+    expect(putBody.role).toBe("agent"); // preserved
+  });
+});


### PR DESCRIPTION
## ops-31.3 — Onboarding seed kit: CLI

### What changed

`tps agent create` now calls `POST /AgentSeed` after generating keys, giving the agent a soul and starter memory from day one.

### New flags

```
tps agent create --id <id>
  --display-name <name>      human-readable name (separate from internal id)
  --soul-file <path>         YAML or JSON file with key:value soul entries
  --no-seed                  skip Flair seeding (register only)
```

### Flow

1. Generate Ed25519 keys (unchanged)
2. Call `POST /AgentSeed` → agent record, soul entries, starter memories created
3. Call `updateAgent()` to write real publicKey (AgentSeed creates with publicKey=pending)
4. Write local agent.yaml config (unchanged)

If caller is not admin, falls back to `registerAgent()` gracefully (no crash).

### New FlairClient methods
- `seedAgent(opts)` → `{ agent, soulEntries, memories }`
- `updateAgent(id, patch)` — read-modify-write (getAgent + PUT full record)

### Tests
3 new — 404/404 pass.

### Companion Flair PR: tpsdev-ai/flair#11