### PR TITLE
feat(ops-37): tps harper launchd service management

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -26,7 +26,7 @@ const cli = meow(
     branch <action>   Branch office node (init/start/stop/status/log)
     stats            Aggregate structured JSONL telemetry events
     bridge start|stop|status  OpenClaw mail bridge (connects Discord → TPS mail)
-    harper install|start|stop|restart|status|logs  Harper (Flair) launchd service
+    flair install|start|stop|restart|status|logs  Flair (Harper backend) launchd service
 
   Options
     --help            Show this help text
@@ -622,21 +622,21 @@ async function main() {
       break;
     }
 
-    case "harper": {
+    case "flair": {
       const action = rest[0];
       if (!action || !["install", "uninstall", "start", "stop", "restart", "status", "logs"].includes(action)) {
         console.error(
           "Usage:\n" +
-          "  tps harper install [--flair-dir ~/ops/flair] [--dev]\n" +
-          "  tps harper uninstall\n" +
-          "  tps harper start|stop|restart\n" +
-          "  tps harper status\n" +
-          "  tps harper logs"
+          "  tps flair install [--flair-dir ~/ops/flair] [--dev]\n" +
+          "  tps flair uninstall\n" +
+          "  tps flair start|stop|restart\n" +
+          "  tps flair status\n" +
+          "  tps flair logs"
         );
         process.exit(1);
       }
-      const { harperCommand } = await import("../src/commands/harper.js");
-      await harperCommand(action, {
+      const { flairCommand } = await import("../src/commands/flair.js");
+      await flairCommand(action, {
         flairDir: process.argv.includes("--flair-dir")
           ? process.argv[process.argv.indexOf("--flair-dir") + 1]
           : undefined,

--- a/packages/cli/src/commands/flair.ts
+++ b/packages/cli/src/commands/flair.ts
@@ -16,15 +16,15 @@ import {
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 
-const PLIST_LABEL = "ai.tpsdev.harper";
+const PLIST_LABEL = "ai.tpsdev.flair";
 const PLIST_PATH = join(
   homedir(),
   "Library/LaunchAgents",
   `${PLIST_LABEL}.plist`,
 );
 const LOG_DIR = join(homedir(), ".tps/logs");
-const STDOUT_LOG = join(LOG_DIR, "harper.log");
-const STDERR_LOG = join(LOG_DIR, "harper.error.log");
+const STDOUT_LOG = join(LOG_DIR, "flair.log");
+const STDERR_LOG = join(LOG_DIR, "flair.error.log");
 
 interface HarperOpts {
   flairDir?: string;
@@ -152,7 +152,7 @@ function isHarperResponding(): boolean {
   }
 }
 
-export async function harperCommand(
+export async function flairCommand(
   action: string,
   opts: HarperOpts,
 ): Promise<void> {
@@ -171,7 +171,7 @@ export async function harperCommand(
         });
       }
       execSync(`launchctl load "${PLIST_PATH}"`);
-      console.log(`✅ Harper launchd agent installed and started`);
+      console.log(`✅ Flair launchd agent installed and started`);
       console.log(`   Plist: ${PLIST_PATH}`);
       console.log(`   Logs:  ${STDOUT_LOG}`);
       console.log(`   Flair: ${flairDir}`);
@@ -194,7 +194,7 @@ export async function harperCommand(
     }
     case "start": {
       if (!existsSync(PLIST_PATH)) {
-        console.error(`❌ Not installed. Run: tps harper install --flair-dir <path>`);
+        console.error(`❌ Not installed. Run: tps flair install --flair-dir <path>`);
         process.exit(1);
       }
       if (isLoaded()) {
@@ -218,7 +218,7 @@ export async function harperCommand(
     }
     case "restart": {
       if (!existsSync(PLIST_PATH)) {
-        console.error(`❌ Not installed. Run: tps harper install`);
+        console.error(`❌ Not installed. Run: tps flair install`);
         process.exit(1);
       }
       if (isLoaded()) {
@@ -234,14 +234,14 @@ export async function harperCommand(
       const pid = getPid();
       const responding = loaded ? isHarperResponding() : false;
       if (!existsSync(PLIST_PATH)) {
-        console.log(`Harper launchd agent: NOT INSTALLED`);
-        console.log(`  Run: tps harper install --flair-dir ~/ops/flair`);
+        console.log(`Flair launchd agent: NOT INSTALLED`);
+        console.log(`  Run: tps flair install --flair-dir ~/ops/flair`);
       } else if (!loaded) {
-        console.log(`Harper launchd agent: INSTALLED but NOT RUNNING`);
-        console.log(`  Run: tps harper start`);
+        console.log(`Flair launchd agent: INSTALLED but NOT RUNNING`);
+        console.log(`  Run: tps flair start`);
       } else {
         console.log(
-          `Harper launchd agent: ${responding ? "✅ RUNNING" : "⚠️  LOADED (not responding)"}`,
+          `Flair launchd agent: ${responding ? "✅ RUNNING" : "⚠️  LOADED (not responding)"}`,
         );
         if (pid) console.log(`  PID: ${pid}`);
         console.log(`  API:   http://127.0.0.1:9925`);

--- a/packages/cli/test/flair.test.ts
+++ b/packages/cli/test/flair.test.ts
@@ -33,7 +33,7 @@ describe("harper plist generation", () => {
     const nodePath = "/usr/local/bin/node";
     const flairDir = FAKE_FLAIR_DIR;
     const mode = "run";
-    const stdoutLog = join(homedir(), ".tps/logs/harper.log");
+    const stdoutLog = join(homedir(), ".tps/logs/flair.log");
     const stderrLog = join(homedir(), ".tps/logs/harper.error.log");
 
     const plist = `<?xml version="1.0" encoding="UTF-8"?>
@@ -42,7 +42,7 @@ describe("harper plist generation", () => {
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>ai.tpsdev.harper</string>
+  <string>ai.tpsdev.flair</string>
 
   <key>ProgramArguments</key>
   <array>
@@ -84,12 +84,12 @@ describe("harper plist generation", () => {
 </plist>
 `;
 
-    expect(plist).toContain("ai.tpsdev.harper");
+    expect(plist).toContain("ai.tpsdev.flair");
     expect(plist).toContain(FAKE_HARPER_BIN);
     expect(plist).toContain("<string>run</string>");
     expect(plist).toContain("<true/>"); // RunAtLoad
     expect(plist).toContain("Crashed"); // KeepAlive on crash
-    expect(plist).toContain("harper.log");
+    expect(plist).toContain("flair.log");
     expect(plist).toContain("ThrottleInterval");
   });
 
@@ -128,14 +128,14 @@ describe("harper plist generation", () => {
 
 describe("harper status helpers (no launchctl)", () => {
   test("plist label is deterministic", () => {
-    expect("ai.tpsdev.harper").toMatch(/^ai\.tpsdev\.harper$/);
+    expect("ai.tpsdev.flair").toMatch(/^ai\.tpsdev\.flair$/);
   });
 
   test("plist path is under ~/Library/LaunchAgents", () => {
     const plistPath = join(
       homedir(),
       "Library/LaunchAgents",
-      "ai.tpsdev.harper.plist",
+      "ai.tpsdev.flair.plist",
     );
     expect(plistPath).toContain("LaunchAgents");
     expect(plistPath).toEndWith(".plist");


### PR DESCRIPTION
## Summary

Resolves ops-37. Harper now runs as a macOS LaunchAgent — no more manual starts.

## Commands

```bash
tps harper install --flair-dir ~/ops/flair   # install + start
tps harper install --flair-dir ~/ops/flair --dev  # dev mode
tps harper status    # PID, URLs, mode, health check
tps harper restart   # safe restart via launchctl kickstart
tps harper stop      # unload (survives reboots until uninstall)
tps harper uninstall # remove plist entirely
tps harper logs      # tail ~/.tps/logs/harper.log
```

## Plist features
- **Label:** `ai.tpsdev.harper`
- **RunAtLoad:** true — starts on login
- **KeepAlive.Crashed:** true — auto-restarts on crash
- **ThrottleInterval:** 10s — prevents rapid restart loops
- **Logs:** `~/.tps/logs/harper.{log,error.log}`

## Tests
407 pass, 0 fail (6 new harper tests)