### PR TITLE
fix(sandbox): nono agent start boots correctly under isolation

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -267,7 +267,7 @@ async function main() {
           const message = msgIdx >= 0 ? process.argv.slice(msgIdx + 1).join(" ") : undefined;
           await runAgent({ action: "run", config: configPath, id: agentId, message });
         } else if (action === "start") {
-          await runAgent({ action: "start", config: configPath, id: agentId, sandbox: process.argv.includes("--sandbox") });
+          await runAgent({ action: "start", config: configPath, id: agentId, sandbox: process.argv.includes("--sandbox"), sandboxed: process.argv.includes("--sandboxed") });
         } else {
           await runAgent({ action: "health", config: configPath, id: agentId });
         }

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -33,6 +33,8 @@ export interface AgentArgs {
   flairUrl?: string;
   json?: boolean;
   sandbox?: boolean;
+  /** Internal: set by re-exec under nono, skips re-wrapping */
+  sandboxed?: boolean;
 }
 
 // ─── create ──────────────────────────────────────────────────────────────────
@@ -354,9 +356,12 @@ export async function runAgent(args: AgentArgs): Promise<void> {
 
       if (args.action === "start") {
         const sandbox = (args as any).sandbox ?? false;
+        const sandboxed = (args as any).sandboxed ?? false;
         const nonoAvailable = findNono();
 
-        if (sandbox || isNonoStrict()) {
+        if (sandboxed) {
+          // Already running inside nono — skip re-exec, proceed to runtime
+        } else if (sandbox || isNonoStrict()) {
           if (!nonoAvailable) {
             if (isNonoStrict()) {
               console.error("❌ --sandbox requires nono (TPS_NONO_STRICT=1). Install from https://nono.sh");
@@ -368,18 +373,21 @@ export async function runAgent(args: AgentArgs): Promise<void> {
             const identityDir = join(homedir(), ".tps", "identity");
             const mailDir = join(homedir(), ".tps", "mail");
             const agentDir = join(homedir(), ".tps", "agents", config.agentId);
+            const bunDir = join(homedir(), ".bun");
+            const tmpDir = process.env.TMPDIR ?? "/tmp";
             const exitCode = runCommandUnderNono(
               "tps-agent-run",
               {
                 workdir: config.workspace,
-                read: [identityDir, agentDir],
-                allow: [mailDir],
+                // System-wide read: bun needs macOS dylibs/frameworks, read-only is safe
+                read: [identityDir, agentDir, bunDir, "/"],
+                allow: [mailDir, tmpDir, config.workspace],
               },
-              [process.execPath, ...process.execArgv, process.argv[1]!, "agent", "start", "--id", config.agentId],
+              [process.execPath, ...process.execArgv, process.argv[1]!, "agent", "start", "--id", config.agentId, "--sandboxed"],
             );
             process.exit(exitCode);
           }
-        } else if (nonoAvailable) {
+        } else if (!sandboxed && nonoAvailable) {
           console.log(`ℹ️  nono available — pass --sandbox to run with isolation`);
         }
 


### PR DESCRIPTION
## Problem
`tps agent start --id ember --sandbox` crashed with `An unknown error occurred (Unexpected)`.

Two root causes:
1. **Missing paths**: bun needs read access to macOS system dylibs and write to `$TMPDIR`; the profile only allowed `.tps/` and `ops/`.
2. **Re-exec loop**: after nono wraps the process, the inner re-exec ran without `--sandbox`, hit the `else if (nonoAvailable)` branch, and exited with code 1.

## Fix
- Pass `--read /` (system read, safe) + `--allow $TMPDIR` + `--allow workspace` to nono
- Add `--sandboxed` flag for the inner re-exec, skipping the nono re-wrap
- `tps.ts` passes `--sandboxed` through to `runAgent()`

## Verified
`tps agent start --id ember --sandbox` boots and `tps agent health --id ember` returns healthy.