### PR TITLE
feat(proxy): claude-oauth provider — OAuth token with auto-refresh

### DIFF
--- a/packages/cli/src/utils/llm-proxy.ts
+++ b/packages/cli/src/utils/llm-proxy.ts
@@ -19,7 +19,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import crypto from "node:crypto";
-import { readFileSync, existsSync, writeFileSync, renameSync } from "node:fs";
+import { readFileSync, existsSync, writeFileSync, renameSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 


### PR DESCRIPTION
## Problem
Ember's Anthropic API key ran out of credits, blocking all development work.

## Solution
New `claude-oauth` proxy provider that uses the existing Claude Code OAuth token:
- Reads `~/.claude/.credentials.json` (populated by Claude Code login)
- Token endpoint: same `api.anthropic.com` but with `Authorization: Bearer <token>`
- Auto-refreshes when within 5 min of expiry (refreshes against `console.anthropic.com/v1/oauth/token`)
- Writes updated credentials back to the file

## Usage
In agent.yaml:
```yaml
llm:
  provider: claude-oauth
  model: claude-sonnet-4-6
  baseUrl: http://localhost:6459
```

No API keys required. Runs against Nathan's Claude Max subscription.

## Changes
- `llm-proxy.ts`: new `ClaudeOAuthCredentials` type, `getValidOAuthToken()`, `refreshOAuthToken()`
- Route regex updated: `/proxy/claude-oauth/...`
- `getProviderConfig` and `forwardRequest` handle the new provider type