### PR TITLE
fix(sandbox): agentDir needs write access for memory.jsonl

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -380,8 +380,8 @@ export async function runAgent(args: AgentArgs): Promise<void> {
               {
                 workdir: config.workspace,
                 // System-wide read: bun needs macOS dylibs/frameworks, read-only is safe
-                read: [identityDir, agentDir, bunDir, "/"],
-                allow: [mailDir, tmpDir, config.workspace],
+                read: [identityDir, bunDir, "/"],
+                allow: [mailDir, tmpDir, config.workspace, agentDir],
               },
               [process.execPath, ...process.execArgv, process.argv[1]!, "agent", "start", "--id", config.agentId, "--sandboxed"],
             );


### PR DESCRIPTION
## Bug
`tps agent start --id ember --sandbox` crashed with:

```
❌ Agent runtime crashed: this.memoryPath = memoryPath;
```

Root cause: `agentDir` (`~/.tps/agents/ember/`) was passed as read-only to nono, but `memory.jsonl` lives there and the agent writes to it on every turn.

## Fix
Move `agentDir` from `read:[]` to `allow:[]` so the agent can write its memory log under nono isolation.