### PR TITLE
fix(runtime): configurable claude-code task timeout (default 30m)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -283,6 +283,7 @@ async function main() {
               model: agentCfg.llm?.model,
               allowedTools: ["Bash", "Read", "Write", "Edit"],
               extraDirs: [join(homedir(), ".tps", "mail", agentId!), join(homedir(), "ops", "tps")],
+              taskTimeoutMs: agentCfg.taskTimeoutMs,
             });
           } else {
             await runAgent({ action: "start", config: configPath, id: agentId, sandbox: process.argv.includes("--sandbox"), sandboxed: process.argv.includes("--sandboxed") });

--- a/packages/cli/src/utils/claude-code-runtime.ts
+++ b/packages/cli/src/utils/claude-code-runtime.ts
@@ -39,6 +39,8 @@ export interface ClaudeCodeConfig {
   extraDirs?: string[];
   /** Agent to notify when done (defaults to "host") */
   supervisorId?: string;
+  /** Max ms to wait for claude to finish a task (default: 30 minutes) */
+  taskTimeoutMs?: number;
 }
 
 interface MailMessage {
@@ -121,6 +123,7 @@ Always commit your work before mailing ${config.supervisorId ?? "host"}:
 async function runClaudeCode(
   message: MailMessage,
   config: ClaudeCodeConfig,
+  taskTimeoutMs: number,
 ): Promise<string> {
   const systemPrompt = buildSystemPrompt(config.workspace, config);
   const model = config.model ?? "claude-sonnet-4-6";
@@ -160,7 +163,7 @@ async function runClaudeCode(
 
     const _timeout = setTimeout(() => {
       proc.kill("SIGTERM");
-    }, 10 * 60 * 1000);
+    }, taskTimeoutMs);
 
     proc.on("close", (code) => {
       clearTimeout(_timeout);
@@ -203,7 +206,7 @@ export async function runClaudeCodeRuntime(config: ClaudeCodeConfig): Promise<vo
       console.log(`[${agentId}] Processing mail from ${msg.from}: ${msg.body.slice(0, 60)}...`);
 
       try {
-        const result = await runClaudeCode(msg, config);
+        const result = await runClaudeCode(msg, config, config.taskTimeoutMs ?? 30 * 60 * 1000);
         console.log(`[${agentId}] Task complete. Result length: ${result.length}`);
         // Send summary back to sender
         const summary = result.length > 500 ? result.slice(0, 500) + "..." : result;


### PR DESCRIPTION
## Problem
Hardcoded 10-minute timeout in `claude-code-runtime.ts` kills the `claude` process via SIGTERM (exit 143) on any task involving compilation or multi-step work.

## Fix
- Add `taskTimeoutMs?: number` to `ClaudeCodeConfig`
- Read `agentCfg.taskTimeoutMs` from `agent.yaml` at startup
- Default raised from 10 min → **30 min**
- Line 162: `config.taskTimeoutMs ?? 30 * 60 * 1000`

## Usage
```yaml
# agent.yaml
taskTimeoutMs: 1800000  # 30 minutes (default)
```

Fixes ops-33 root cause (Ember kept timing out building the binary).