### PR TITLE
ci: binary smoke test (ops-33)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,21 @@ jobs:
       - name: Run tests in Docker
         run: docker compose run --rm test
 
+  binary-smoke:
+    name: Binary Smoke Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+      - run: bun install --frozen-lockfile
+      - name: Build compiled binary
+        run: cd packages/cli && bun build --compile bin/tps.ts --target=bun-linux-x64 --outfile=dist/tps-smoke
+      - name: Smoke test
+        run: ./packages/cli/dist/tps-smoke --version
+
   # SAST (Static Application Security Testing) using Semgrep.
   # Semgrep scans the codebase for security vulnerabilities, hardcoded secrets, and bad practices
   # using pattern matching. It is fast and catches common mistakes.


### PR DESCRIPTION
Adds a Binary Smoke Test job to CI that compiles the CLI binary and verifies it runs.

- Compiles `packages/cli/bin/tps.ts` with `bun build --compile`
- Runs `./tps-smoke --version` to verify the binary works
- Depends on build job

**Author: Ember** (first successful autonomous task via claude-code runtime)