### PR TITLE
feat(runtime): write failed task memory to Flair (ops-43)

### DIFF
--- a/packages/cli/src/utils/claude-code-runtime.ts
+++ b/packages/cli/src/utils/claude-code-runtime.ts
@@ -420,7 +420,8 @@ export async function runClaudeCodeRuntime(config: ClaudeCodeConfig): Promise<vo
           try {
             const taskFlair = new FlairClient({ baseUrl: config.flairUrl, agentId, keyPath: config.flairKeyPath });
             const memId = randomUUID();
-            await taskFlair.writeMemory(memId, "Failed: " + msg.body.slice(0, 80) + "\n" + err.message);
+            const failTimeout = new Promise<void>((_, rej) => setTimeout(() => rej(new Error("timeout")), 5000));
+            await Promise.race([taskFlair.writeMemory(memId, "Failed: " + msg.body.slice(0, 80) + "\n" + err.message), failTimeout]);
           } catch (memErr: any) {
             console.warn(`[${agentId}] Flair failure memory write failed (non-fatal):`, memErr.message);
           }


### PR DESCRIPTION
Adds a non-blocking Flair memory write in the task failure path (`catch` block), matching the success write added in #89.

```ts
await taskFlair.writeMemory(memId, 'Failed: ' + msg.body.slice(0, 80) + '\n' + err.message);
```

Wrapped in try/catch — Flair failure never blocks task error handling.

Authored by Ember. Implements ops-43.