### PR TITLE
fix(runtime): add 5s timeout to Flair memory writes (ops-44)

### DIFF
--- a/packages/cli/src/utils/claude-code-runtime.ts
+++ b/packages/cli/src/utils/claude-code-runtime.ts
@@ -401,7 +401,8 @@ export async function runClaudeCodeRuntime(config: ClaudeCodeConfig): Promise<vo
         try {
           const taskFlair = new FlairClient({ baseUrl: config.flairUrl, agentId, keyPath: config.flairKeyPath });
           const memId = randomUUID();
-          await taskFlair.writeMemory(memId, "Completed: " + msg.body.slice(0, 80) + "\n" + summary);
+          const timeout = new Promise<void>((_, rej) => setTimeout(() => rej(new Error("timeout")), 5000));
+          await Promise.race([taskFlair.writeMemory(memId, "Completed: " + msg.body.slice(0, 80) + "\n" + summary), timeout]);
         } catch (memErr: any) {
           console.warn(`[${agentId}] Flair memory write failed (non-fatal):`, memErr.message);
         }


### PR DESCRIPTION
Flair memory writes were `await`ed with no timeout. If Flair is slow or the TCP connection stalls, the entire poll loop blocks — the agent appears alive but stops processing mail.

Fix: wrap each `writeMemory` call in `Promise.race` with a 5-second timeout. Timeout is caught by the existing try/catch and logged as a non-fatal warning.

```ts
const timeout = new Promise<void>((_, rej) => setTimeout(() => rej(new Error("timeout")), 5000));
await Promise.race([taskFlair.writeMemory(...), timeout]);
```

Root cause of the stall seen between ops-41 and ops-43.

Authored by Anvil.