### PR TITLE
feat(agent): graceful turn limit — auto-commit + mail notification

### DIFF
--- a/packages/agent/src/runtime/event-loop.ts
+++ b/packages/agent/src/runtime/event-loop.ts
@@ -562,7 +562,7 @@ export class EventLoop {
     }
 
     // Mail the sender (or operator as fallback) with a progress report
-    const recipient = sender && sender !== "unknown" ? sender : "operator";
+    const recipient = sender && sender !== "unknown" ? sender : "host";
     const mailBody = [
       `Hit turn limit (${turns}/${this.deps.config.maxToolTurns ?? 50}) on the current task.`,
       `Any staged changes have been auto-committed to the workspace.`,


### PR DESCRIPTION
## Graceful Turn Limit (PR #80 re-implementation)

When Ember hits the tool turn limit, instead of crashing silently:

1. **Auto-commit**: `git add -A && git commit --author=...` with a WIP message so staged changes survive
2. **Mail notification**: Sends a message to the original task sender (or `host` as fallback) explaining what happened and asking to restart or break the task into smaller steps

Both steps are best-effort — failures don't crash the loop further.

### Changes
- `packages/agent/src/runtime/event-loop.ts` — `notifyTurnLimitReached(sender, turns)`, sender threading through `processMessage`
- `packages/agent/src/runtime/agent.ts` — pass `mailClient` to EventLoop
- `packages/agent/src/runtime/types.ts` — add `claude-oauth` to ProviderName
- `packages/agent/src/config.ts` — add `claude-oauth` to provider union
- `packages/agent/src/llm/provider.ts` — handle `claude-oauth` provider case

All 68 agent tests pass. Fallback recipient is `host` (not `rockit`).