### PR TITLE
feat(workspace): WorkspaceProvider + agent lifecycle extraction (ops-47 phase 1)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -278,10 +278,40 @@ async function main() {
             const { load: parseYaml } = await import("js-yaml");
             const cfgPath = configPath ?? join(homedir(), ".tps", "agents", agentId!, "agent.yaml");
             const agentCfg = parseYaml(readFileSync(cfgPath, "utf-8")) as any;
+            const agentWorkspace = agentCfg.workspace ?? join(homedir(), "ops", "tps");
+
+            // OPS-47: Build workspace provider from agent.yaml config
+            const { GitWorkspaceProvider } = await import("../src/utils/workspace-provider.js");
+            let workspaceProvider;
+            const wpCfg = agentCfg.workspaceProvider;
+            if (wpCfg?.type === "git") {
+              workspaceProvider = new GitWorkspaceProvider(agentWorkspace, {
+                remote: wpCfg.remote,
+                baseBranch: wpCfg.baseBranch,
+                author: wpCfg.author,
+                failureMode: wpCfg.failureMode,
+              });
+            } else if (!wpCfg) {
+              // Default: use git provider if workspace is a git repo
+              try {
+                const { spawnSync } = await import("node:child_process");
+                const check = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+                  cwd: agentWorkspace, encoding: "utf-8",
+                });
+                if (check.status === 0 && check.stdout.trim() === "true") {
+                  workspaceProvider = new GitWorkspaceProvider(agentWorkspace, {
+                    author: `${agentId} <${agentId}@tps.dev>`,
+                  });
+                }
+              } catch {
+                // Not a git repo — no workspace provider
+              }
+            }
+
             const { runClaudeCodeRuntime } = await import("../src/utils/claude-code-runtime.js");
             await runClaudeCodeRuntime({
               agentId: agentId!,
-              workspace: agentCfg.workspace ?? join(homedir(), "ops", "tps"),
+              workspace: agentWorkspace,
               mailDir: agentCfg.mailDir ?? join(homedir(), ".tps", "mail"),
               model: agentCfg.llm?.model,
               allowedTools: ["Bash", "Read", "Write", "Edit"],
@@ -289,6 +319,7 @@ async function main() {
               taskTimeoutMs: agentCfg.taskTimeoutMs,
               flairUrl: agentCfg.flair?.url ?? process.env.FLAIR_URL,
               flairKeyPath: agentCfg.flair?.keyPath,
+              workspaceProvider,
             });
           } else {
             await runAgent({ action: "start", config: configPath, id: agentId, sandbox: process.argv.includes("--sandbox"), sandboxed: process.argv.includes("--sandboxed") });

--- a/packages/cli/src/utils/agent-lifecycle.ts
+++ b/packages/cli/src/utils/agent-lifecycle.ts
@@ -1,0 +1,204 @@
+/**
+ * agent-lifecycle.ts — Shared Flair lifecycle hooks for agent runtimes (OPS-47)
+ *
+ * Extracts boot context, memory search, task memory writes, and topic catch-up
+ * from claude-code-runtime.ts so both EventLoop and runClaudeCodeRuntime can
+ * call the same hooks without inline duplication.
+ *
+ * Each function is stateless and takes explicit dependencies (FlairClient,
+ * agentId, etc.) rather than holding global state.
+ */
+
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { FlairClient } from "./flair-client.js";
+import { catchUpTopics as _catchUpTopics } from "./mail-topics.js";
+import type { WorkspaceProvider } from "./workspace-provider.js";
+
+// ── Boot context ───────────────────────────────────────────────────────────
+
+function getFallbackDir(agentId: string): string {
+  return join(homedir(), ".tps", "agents", agentId, "fallback");
+}
+
+function getFallbackSoulPath(agentId: string): string {
+  return join(getFallbackDir(agentId), "SOUL.md");
+}
+
+/**
+ * Snapshot the agent's soul from Flair to disk for offline fallback.
+ */
+export async function snapshotSoulToDisk(flair: FlairClient, agentId: string): Promise<void> {
+  try {
+    const soul = await flair.getSoul();
+    if (soul.length === 0) return;
+
+    const fallbackDir = getFallbackDir(agentId);
+    mkdirSync(fallbackDir, { recursive: true });
+
+    const content = [
+      `# Soul snapshot for ${agentId}`,
+      `# Captured: ${new Date().toISOString()}`,
+      "",
+      ...soul.map(e => `**${e.key}:** ${e.value}`),
+    ].join("\n");
+
+    writeFileSync(getFallbackSoulPath(agentId), content, "utf-8");
+  } catch {
+    // non-fatal
+  }
+}
+
+/**
+ * Build boot context: identity (from Flair or disk fallback) + runtime block.
+ * Returns { systemPrompt, identitySource } for the runtime to use.
+ */
+export async function bootContext(
+  flair: FlairClient,
+  agentId: string,
+  taskQuery: string,
+  workspace: string,
+  opts?: {
+    allowedTools?: string[];
+    supervisorId?: string;
+  },
+): Promise<{ systemPrompt: string; identitySource: "flair" | "disk" }> {
+  const parts: string[] = [];
+  let identitySource: "flair" | "disk" | null = null;
+
+  const flairOnline = await flair.ping();
+
+  if (flairOnline) {
+    try {
+      const context = await flair.bootstrap({ query: taskQuery });
+      if (context.trim()) {
+        parts.push(context);
+        identitySource = "flair";
+      }
+    } catch {
+      // fall through to disk
+    }
+  }
+
+  if (identitySource !== "flair") {
+    const fallbackPath = getFallbackSoulPath(agentId);
+    if (existsSync(fallbackPath)) {
+      const content = readFileSync(fallbackPath, "utf-8").trim();
+      if (content) {
+        parts.push(content.slice(0, 2000));
+        identitySource = "disk";
+        console.warn(`[${agentId}] ⚠️  Flair offline — using stale disk fallback (${fallbackPath})`);
+      }
+    }
+
+    if (identitySource !== "disk") {
+      const workspaceSoul = join(workspace, "SOUL.md");
+      if (existsSync(workspaceSoul)) {
+        const content = readFileSync(workspaceSoul, "utf-8").trim();
+        if (content) {
+          parts.push(content.slice(0, 2000));
+          identitySource = "disk";
+          console.warn(`[${agentId}] ⚠️  Flair offline — using workspace SOUL.md fallback`);
+        }
+      }
+    }
+  }
+
+  if (identitySource === null) {
+    throw new Error(
+      `No system prompt available: Flair offline and no disk fallback found. ` +
+      `Run: tps agent soul --id ${agentId} to seed Flair, or create a fallback at ${getFallbackSoulPath(agentId)}`
+    );
+  }
+
+  // Runtime context block
+  const tools = (opts?.allowedTools ?? ["Bash", "Read", "Write", "Edit"]).join(", ");
+  const supervisor = opts?.supervisorId ?? "host";
+  parts.push(`
+## Runtime Context
+
+You are running as agent \`${agentId}\` via Claude Code CLI.
+Your workspace: ${workspace}
+Tools available: ${tools}
+System prompt sourced from: ${identitySource === "flair" ? "Flair (live)" : "⚠️ disk fallback"}
+
+When you finish a task, use Bash to send mail:
+  cd ${workspace} && tps mail send ${supervisor} "done: <summary>"
+
+Always commit your work before mailing ${supervisor}:
+  git add -A && git commit --author="${agentId} <${agentId}@tps.dev>" -m "feat: ..."
+`.trim());
+
+  return { systemPrompt: parts.join("\n\n"), identitySource };
+}
+
+// ── Past experience search ─────────────────────────────────────────────────
+
+/**
+ * Search Flair for relevant past experience. Returns a formatted block
+ * suitable for appending to the system prompt, or empty string.
+ */
+export async function searchPastExperience(
+  flair: FlairClient,
+  taskDescription: string,
+): Promise<string> {
+  try {
+    const flairOnline = await flair.ping();
+    if (!flairOnline) return "";
+
+    const searchResults = await flair.search(taskDescription.slice(0, 200), 5);
+    if (searchResults.length === 0) return "";
+
+    const experienceBlock = searchResults
+      .map(r => `- ${r.content?.slice(0, 200) ?? r.id}`)
+      .join("\n");
+    return `## Relevant Past Experience\n${experienceBlock}`;
+  } catch {
+    return "";
+  }
+}
+
+// ── Task memory writes ─────────────────────────────────────────────────────
+
+/**
+ * Write structured task memory to Flair. Non-blocking with 5s timeout.
+ */
+export async function writeTaskMemory(
+  flair: FlairClient,
+  agentId: string,
+  type: "completion" | "failure",
+  data: {
+    task: string;
+    summary?: string;
+    error?: string;
+    durationMs?: number;
+    workspaceRef?: string;
+    files?: string[];
+  },
+): Promise<void> {
+  try {
+    const memId = `${agentId}-${Date.now()}`;
+    const timeout = new Promise<void>((_, rej) => setTimeout(() => rej(new Error("timeout")), 5000));
+
+    const memory = JSON.stringify({
+      type: type === "completion" ? "task_completion" : "task_failure",
+      task: data.task.slice(0, 80),
+      ...(data.summary ? { summary: data.summary.slice(0, 500) } : {}),
+      ...(data.error ? { error: data.error.slice(0, 200) } : {}),
+      ...(data.durationMs != null ? { durationMs: data.durationMs } : {}),
+      ...(data.workspaceRef ? { workspaceRef: data.workspaceRef } : {}),
+      ...(data.files ? { files: data.files } : {}),
+      timestamp: new Date().toISOString(),
+    });
+
+    await Promise.race([flair.writeMemory(memId, memory), timeout]);
+  } catch (err: any) {
+    console.warn(`[${agentId}] Flair ${type} memory write failed (non-fatal):`, err.message);
+  }
+}
+
+// ── Topic catch-up (re-export) ─────────────────────────────────────────────
+
+/** Re-export catchUpTopics for use by both runtimes. */
+export const catchUpTopics = _catchUpTopics;

--- a/packages/cli/src/utils/claude-code-runtime.ts
+++ b/packages/cli/src/utils/claude-code-runtime.ts
@@ -27,18 +27,26 @@
  *   - TPS mail (inbox/outbox)
  *   - Flair (soul + memories)
  *   - Disk fallback (daily snapshot from Flair)
+ *   - WorkspaceProvider (OPS-47) for workspace lifecycle
  */
 
 import { spawn } from "node:child_process";
 import {
   readFileSync, existsSync, mkdirSync, readdirSync,
-  renameSync, writeFileSync, appendFileSync, createWriteStream, statSync,
+  renameSync, writeFileSync, appendFileSync, createWriteStream,
 } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { FlairClient } from "./flair-client.js";
-import { catchUpTopics } from "./mail-topics.js";
+import {
+  snapshotSoulToDisk,
+  bootContext,
+  searchPastExperience,
+  writeTaskMemory,
+  catchUpTopics,
+} from "./agent-lifecycle.js";
+import type { WorkspaceProvider } from "./workspace-provider.js";
 
 /** How often to snapshot Flair soul to disk (ms) */
 const FLAIR_SNAPSHOT_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
@@ -62,6 +70,8 @@ export interface ClaudeCodeConfig {
   flairUrl?: string;
   /** Path to Ed25519 private key for Flair auth (default: ~/.tps/identity/<agentId>.key) */
   flairKeyPath?: string;
+  /** Optional workspace provider for lifecycle management (OPS-47) */
+  workspaceProvider?: WorkspaceProvider;
 }
 
 interface MailMessage {
@@ -113,143 +123,32 @@ function sendMail(mailDir: string, from: string, to: string, body: string): void
   renameSync(tmpPath, newPath);
 }
 
-// ─── Flair + fallback ───────────────────────────────────────────────────────
-
-function getFallbackDir(agentId: string): string {
-  return join(homedir(), ".tps", "agents", agentId, "fallback");
-}
+// ─── System prompt (delegates to agent-lifecycle) ────────────────────────────
 
 function getFallbackSoulPath(agentId: string): string {
-  return join(getFallbackDir(agentId), "SOUL.md");
+  return join(homedir(), ".tps", "agents", agentId, "fallback", "SOUL.md");
 }
 
-/**
- * Snapshot the agent's soul from Flair to disk.
- * Called on a schedule so the fallback file stays fresh.
- */
-async function snapshotSoulToDisk(flair: FlairClient, agentId: string): Promise<void> {
-  try {
-    const soul = await flair.getSoul();
-    if (soul.length === 0) return;
-
-    const fallbackDir = getFallbackDir(agentId);
-    mkdirSync(fallbackDir, { recursive: true });
-
-    const content = [
-      `# Soul snapshot for ${agentId}`,
-      `# Captured: ${new Date().toISOString()}`,
-      "",
-      ...soul.map(e => `**${e.key}:** ${e.value}`),
-    ].join("\n");
-
-    writeFileSync(getFallbackSoulPath(agentId), content, "utf-8");
-  } catch {
-    // non-fatal — snapshot failure doesn't block the task
-  }
-}
-
-/**
- * Build system prompt from Flair (primary) or disk fallback.
- * Throws if neither is available.
- */
 async function buildSystemPrompt(
   message: MailMessage,
   config: ClaudeCodeConfig,
 ): Promise<string> {
   const { agentId, workspace, allowedTools, supervisorId, flairUrl, flairKeyPath } = config;
-  const parts: string[] = [];
 
-  // ── 1. Identity block ──────────────────────────────────────────────────────
-  let identitySource: "flair" | "disk" | null = null;
+  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath });
 
-  const flair = new FlairClient({
-    baseUrl: flairUrl,
-    agentId,
-    keyPath: flairKeyPath,
-  });
+  const { systemPrompt, identitySource } = await bootContext(
+    flair, agentId, message.body.slice(0, 100), workspace,
+    { allowedTools, supervisorId },
+  );
 
-  const flairOnline = await flair.ping();
-
-  if (flairOnline) {
-    try {
-      const taskQuery = message.body.slice(0, 100);
-      const context = await flair.bootstrap({ query: taskQuery });
-      if (context.trim()) {
-        parts.push(context);
-        identitySource = "flair";
-      }
-    } catch {
-      // fall through to disk
-    }
+  // Append past experience search
+  const experience = await searchPastExperience(flair, message.body);
+  if (experience) {
+    return systemPrompt + "\n\n" + experience;
   }
 
-  if (identitySource !== "flair") {
-    // Flair offline or returned empty — try disk fallback
-    const fallbackPath = getFallbackSoulPath(agentId);
-    if (existsSync(fallbackPath)) {
-      const content = readFileSync(fallbackPath, "utf-8").trim();
-      if (content) {
-        parts.push(content.slice(0, 2000));
-        identitySource = "disk";
-        console.warn(`[${agentId}] ⚠️  Flair offline — using stale disk fallback (${fallbackPath})`);
-      }
-    }
-
-    // Also try workspace SOUL.md as last resort
-    if (identitySource !== "disk") {
-      const workspaceSoul = join(workspace, "SOUL.md");
-      if (existsSync(workspaceSoul)) {
-        const content = readFileSync(workspaceSoul, "utf-8").trim();
-        if (content) {
-          parts.push(content.slice(0, 2000));
-          identitySource = "disk";
-          console.warn(`[${agentId}] ⚠️  Flair offline — using workspace SOUL.md fallback`);
-        }
-      }
-    }
-  }
-
-  if (identitySource === null) {
-    throw new Error(
-      `No system prompt available: Flair offline and no disk fallback found. ` +
-      `Run: tps agent soul --id ${agentId} to seed Flair, or create a fallback at ${getFallbackSoulPath(agentId)}`
-    );
-  }
-
-  // ── 1b. Relevant past experience (non-blocking search) ──────────────────────
-  if (flairOnline) {
-    try {
-      const searchResults = await flair.search(message.body.slice(0, 200), 5);
-      if (searchResults.length > 0) {
-        const experienceBlock = searchResults
-          .map(r => `- ${r.content?.slice(0, 200) ?? r.id}`)
-          .join("\n");
-        parts.push(`## Relevant Past Experience\n${experienceBlock}`);
-      }
-    } catch {
-      // Non-blocking: skip if search fails
-    }
-  }
-
-  // ── 2. Runtime context ─────────────────────────────────────────────────────
-  const tools = (allowedTools ?? ["Bash", "Read", "Write", "Edit"]).join(", ");
-  const supervisor = supervisorId ?? "host";
-  parts.push(`
-## Runtime Context
-
-You are running as agent \`${agentId}\` via Claude Code CLI.
-Your workspace: ${workspace}
-Tools available: ${tools}
-System prompt sourced from: ${identitySource === "flair" ? "Flair (live)" : "⚠️ disk fallback"}
-
-When you finish a task, use Bash to send mail:
-  cd ${workspace} && tps mail send ${supervisor} "done: <summary>"
-
-Always commit your work before mailing ${supervisor}:
-  git add -A && git commit --author="${agentId} <${agentId}@tps.dev>" -m "feat: ..."
-`.trim());
-
-  return parts.join("\n\n");
+  return systemPrompt;
 }
 
 // ─── Claude invocation ───────────────────────────────────────────────────────
@@ -368,7 +267,7 @@ async function runClaudeCode(
 // ─── Main loop ───────────────────────────────────────────────────────────────
 
 export async function runClaudeCodeRuntime(config: ClaudeCodeConfig): Promise<void> {
-  const { agentId, mailDir, workspace, flairUrl, flairKeyPath } = config;
+  const { agentId, mailDir, workspace, flairUrl, flairKeyPath, workspaceProvider } = config;
 
   // Write PID file
   const pidPath = join(workspace, ".tps-agent.pid");
@@ -398,6 +297,26 @@ export async function runClaudeCodeRuntime(config: ClaudeCodeConfig): Promise<vo
     console.warn(`[${agentId}] Topic catch-up failed at boot: ${err.message}`);
   }
 
+  // Boot: workspace lifecycle — stash leftover state, reset to baseline (OPS-47)
+  if (workspaceProvider) {
+    try {
+      await workspaceProvider.checkpoint("pre-boot-stash");
+      console.log(`[${agentId}] Workspace pre-boot checkpoint saved`);
+    } catch (err: any) {
+      console.warn(`[${agentId}] Workspace pre-boot checkpoint failed (non-fatal): ${err.message}`);
+    }
+
+    try {
+      const base = await workspaceProvider.baseline();
+      await workspaceProvider.reset(base);
+      console.log(`[${agentId}] Workspace reset to baseline: ${base.label ?? base.ref.slice(0, 7)}`);
+    } catch (err: any) {
+      console.error(`[${agentId}] Workspace baseline reset failed: ${err.message}`);
+      // reset() failure → fail hard per Kern's review
+      throw err;
+    }
+  }
+
   let lastSnapshot = Date.now();
   const POLL_MS = 5000;
 
@@ -417,6 +336,16 @@ export async function runClaudeCodeRuntime(config: ClaudeCodeConfig): Promise<vo
     for (const msg of messages) {
       console.log(`[${agentId}] Processing mail from ${msg.from}: ${msg.body.slice(0, 60)}...`);
 
+      // Task start: workspace snapshot (OPS-47)
+      let preTaskSnapshot;
+      if (workspaceProvider) {
+        try {
+          preTaskSnapshot = await workspaceProvider.snapshot(`pre-task`);
+        } catch (err: any) {
+          console.warn(`[${agentId}] Pre-task workspace snapshot failed: ${err.message}`);
+        }
+      }
+
       const taskStartMs = Date.now();
       try {
         const result = await runClaudeCode(msg, config, config.taskTimeoutMs ?? 30 * 60 * 1000);
@@ -424,22 +353,27 @@ export async function runClaudeCodeRuntime(config: ClaudeCodeConfig): Promise<vo
         const summary = result.length > 500 ? result.slice(0, 500) + "..." : result;
         sendMail(mailDir, agentId, msg.from, `Task complete:\n\n${summary}`);
 
-        // Non-blocking: write task completion memory to Flair
-        try {
-          const taskFlair = new FlairClient({ baseUrl: config.flairUrl, agentId, keyPath: config.flairKeyPath });
-          const memId = `${agentId}-${Date.now()}`;
-          const timeout = new Promise<void>((_, rej) => setTimeout(() => rej(new Error("timeout")), 5000));
-          const completionMemory = JSON.stringify({
-            type: "task_completion",
-            task: msg.body.slice(0, 80),
-            summary: summary.slice(0, 500),
-            timestamp: new Date().toISOString(),
-            durationMs: Date.now() - taskStartMs,
-          });
-          await Promise.race([taskFlair.writeMemory(memId, completionMemory), timeout]);
-        } catch (memErr: any) {
-          console.warn(`[${agentId}] Flair memory write failed (non-fatal):`, memErr.message);
+        // Task complete: workspace checkpoint (OPS-47)
+        let checkpointState;
+        if (workspaceProvider) {
+          try {
+            checkpointState = await workspaceProvider.checkpoint(
+              "task-done",
+              `task complete: ${msg.body.slice(0, 60)}`,
+            );
+          } catch (err: any) {
+            console.warn(`[${agentId}] Post-task workspace checkpoint failed: ${err.message}`);
+          }
         }
+
+        // Write task completion memory to Flair (via agent-lifecycle)
+        const taskFlair = new FlairClient({ baseUrl: config.flairUrl, agentId, keyPath: config.flairKeyPath });
+        await writeTaskMemory(taskFlair, agentId, "completion", {
+          task: msg.body,
+          summary,
+          durationMs: Date.now() - taskStartMs,
+          workspaceRef: checkpointState?.ref,
+        });
       } catch (err: any) {
         // Hard fail: no system prompt available → notify supervisor
         if (err.message.startsWith("No system prompt available")) {
@@ -450,21 +384,24 @@ export async function runClaudeCodeRuntime(config: ClaudeCodeConfig): Promise<vo
           console.error(`[${agentId}] Task failed:`, err.message);
           sendMail(mailDir, agentId, msg.from, `Task failed: ${err.message}`);
 
-          // Non-blocking: write task failure memory to Flair
-          try {
-            const taskFlair = new FlairClient({ baseUrl: config.flairUrl, agentId, keyPath: config.flairKeyPath });
-            const memId = `${agentId}-${Date.now()}`;
-            const failTimeout = new Promise<void>((_, rej) => setTimeout(() => rej(new Error("timeout")), 5000));
-            const failureMemory = JSON.stringify({
-              type: "task_failure",
-              task: msg.body.slice(0, 80),
-              error: err.message.slice(0, 200),
-              timestamp: new Date().toISOString(),
-            });
-            await Promise.race([taskFlair.writeMemory(memId, failureMemory), failTimeout]);
-          } catch (memErr: any) {
-            console.warn(`[${agentId}] Flair failure memory write failed (non-fatal):`, memErr.message);
+          // Task failure: workspace checkpoint (OPS-47)
+          if (workspaceProvider) {
+            try {
+              await workspaceProvider.checkpoint(
+                "task-failed",
+                `WIP: failed — ${err.message.slice(0, 60)}`,
+              );
+            } catch (cpErr: any) {
+              console.warn(`[${agentId}] Failure checkpoint failed: ${cpErr.message}`);
+            }
           }
+
+          // Write task failure memory to Flair (via agent-lifecycle)
+          const taskFlair = new FlairClient({ baseUrl: config.flairUrl, agentId, keyPath: config.flairKeyPath });
+          await writeTaskMemory(taskFlair, agentId, "failure", {
+            task: msg.body,
+            error: err.message,
+          });
         }
       }
     }

--- a/packages/cli/src/utils/workspace-provider.ts
+++ b/packages/cli/src/utils/workspace-provider.ts
@@ -1,0 +1,280 @@
+/**
+ * workspace-provider.ts — Workspace lifecycle abstraction (OPS-47 Phase 1)
+ *
+ * Provides a provider interface for workspace state management.
+ * Phase 1 ships GitWorkspaceProvider; filesystem and API providers come later.
+ *
+ * Security:
+ *   S47-A: All git ops use spawnSync with shell: false, array args, ref validation
+ *   S47-B: failureMode controls baseline() failure behavior (warn vs hard)
+ *   S47-C: State is agent-scoped — no cross-agent reset()
+ */
+
+import { spawnSync } from "node:child_process";
+
+// ── Interfaces ─────────────────────────────────────────────────────────────
+
+export interface WorkspaceState {
+  ref: string;                         // opaque reference (git SHA, snapshot ID)
+  label?: string;                      // human-readable ("pre-task-42")
+  timestamp: string;                   // ISO 8601
+  provider: string;                    // "git" | "filesystem" | "api"
+  metadata?: Record<string, unknown>;  // provider-specific
+}
+
+export interface WorkspaceChanges {
+  summary: string;       // human-readable diff summary
+  files?: string[];      // changed file paths
+  details?: string;      // full diff or change log
+}
+
+export type StateRef = string | WorkspaceState;
+
+export interface WorkspaceProvider {
+  readonly type: string;
+
+  /** Capture current workspace state. Non-destructive. */
+  snapshot(label?: string): Promise<WorkspaceState>;
+
+  /** Reset workspace to a known state. Destructive. */
+  reset(to: StateRef): Promise<void>;
+
+  /** Save current state with a label (like git commit). */
+  checkpoint(label: string, message?: string): Promise<WorkspaceState>;
+
+  /** What changed since a given state ref. */
+  diff(from: StateRef): Promise<WorkspaceChanges>;
+
+  /** Get the "known good" baseline state (e.g. origin/main). */
+  baseline(): Promise<WorkspaceState>;
+}
+
+// ── Ref validation (S47-A) ─────────────────────────────────────────────────
+
+const SAFE_REF_RE = /^[a-zA-Z0-9._\/-]+$/;
+
+function validateRef(ref: string): void {
+  if (!SAFE_REF_RE.test(ref)) {
+    throw new Error(`Invalid ref: "${ref}" — must match ${SAFE_REF_RE}`);
+  }
+}
+
+function resolveRef(to: StateRef): string {
+  const ref = typeof to === "string" ? to : to.ref;
+  validateRef(ref);
+  return ref;
+}
+
+// ── GitWorkspaceProvider ───────────────────────────────────────────────────
+
+export interface GitWorkspaceConfig {
+  remote?: string;                       // default: "origin"
+  baseBranch?: string;                   // default: "main"
+  author?: string;                       // "Ember <ember@tps.dev>"
+  failureMode?: "warn" | "hard";         // baseline() failure behavior
+}
+
+export class GitWorkspaceProvider implements WorkspaceProvider {
+  readonly type = "git";
+
+  private readonly cwd: string;
+  private readonly remote: string;
+  private readonly baseBranch: string;
+  private readonly author: string;
+  private readonly failureMode: "warn" | "hard";
+
+  /** Track refs we've produced — only accept our own refs (S47-A) */
+  private readonly knownRefs = new Set<string>();
+
+  constructor(cwd: string, config: GitWorkspaceConfig = {}) {
+    this.cwd = cwd;
+    this.remote = config.remote ?? "origin";
+    this.baseBranch = config.baseBranch ?? "main";
+    this.author = config.author ?? "Agent <agent@tps.dev>";
+    this.failureMode = config.failureMode ?? "warn";
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────
+
+  private git(...args: string[]): { stdout: string; stderr: string; ok: boolean } {
+    const result = spawnSync("git", args, {
+      cwd: this.cwd,
+      encoding: "utf-8",
+      // S47-A: shell: false is the default for spawnSync — never override
+    });
+    return {
+      stdout: (result.stdout ?? "").trim(),
+      stderr: (result.stderr ?? "").trim(),
+      ok: result.status === 0,
+    };
+  }
+
+  private gitOrThrow(...args: string[]): string {
+    const r = this.git(...args);
+    if (!r.ok) {
+      throw new Error(`git ${args[0]} failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+  }
+
+  private isClean(): boolean {
+    return this.git("status", "--porcelain").stdout === "";
+  }
+
+  private headSha(): string {
+    return this.gitOrThrow("rev-parse", "HEAD");
+  }
+
+  private currentBranch(): string | null {
+    const r = this.git("rev-parse", "--abbrev-ref", "HEAD");
+    return r.ok && r.stdout !== "HEAD" ? r.stdout : null;
+  }
+
+  private registerRef(ref: string): void {
+    this.knownRefs.add(ref);
+  }
+
+  private assertKnownRef(ref: string): void {
+    if (!this.knownRefs.has(ref)) {
+      throw new Error(
+        `Ref "${ref}" was not produced by this provider. ` +
+        `Only refs from snapshot(), checkpoint(), or baseline() are accepted (S47-A).`
+      );
+    }
+  }
+
+  // ── WorkspaceProvider ──────────────────────────────────────────────────
+
+  async snapshot(label?: string): Promise<WorkspaceState> {
+    const sha = this.headSha();
+    const branch = this.currentBranch();
+    const dirty = !this.isClean();
+
+    this.registerRef(sha);
+
+    return {
+      ref: sha,
+      label: label ?? (dirty ? `snapshot-dirty-${sha.slice(0, 7)}` : `snapshot-${sha.slice(0, 7)}`),
+      timestamp: new Date().toISOString(),
+      provider: "git",
+      metadata: {
+        branch,
+        dirty,
+      },
+    };
+  }
+
+  async reset(to: StateRef): Promise<void> {
+    const ref = resolveRef(to);
+    this.assertKnownRef(ref);
+
+    // Auto-stash uncommitted work (S47: reset() finds uncommitted work)
+    if (!this.isClean()) {
+      const stashMsg = `auto-stash: pre-reset ${new Date().toISOString()}`;
+      const stash = this.git("stash", "push", "-m", stashMsg);
+      if (stash.ok) {
+        console.log(`[workspace] Stashed uncommitted changes: ${stashMsg}`);
+      } else {
+        // Stash failed — checkpoint to recovery branch instead
+        const recoveryBranch = `recovery/${Date.now()}`;
+        validateRef(recoveryBranch);
+        this.gitOrThrow("checkout", "-b", recoveryBranch);
+        this.gitOrThrow("add", "-A");
+        this.git("commit", "--author", this.author, "-m", `WIP: recovery before reset`);
+        console.warn(`[workspace] Stash failed — saved to branch ${recoveryBranch}`);
+      }
+    }
+
+    // S47-A: double-dash separator prevents ref/path ambiguity
+    // Use checkout for SHA refs
+    const result = this.git("checkout", ref, "--");
+    if (!result.ok) {
+      // reset() failure → fail hard (Kern's review)
+      throw new Error(`workspace reset failed: ${result.stderr}`);
+    }
+  }
+
+  async checkpoint(label: string, message?: string): Promise<WorkspaceState> {
+    // No-op if working tree is clean
+    if (this.isClean()) {
+      const sha = this.headSha();
+      this.registerRef(sha);
+      return {
+        ref: sha,
+        label,
+        timestamp: new Date().toISOString(),
+        provider: "git",
+        metadata: { branch: this.currentBranch(), noop: true },
+      };
+    }
+
+    this.gitOrThrow("add", "-A");
+    this.gitOrThrow("commit", "--author", this.author, "-m", message ?? label);
+
+    const sha = this.headSha();
+    this.registerRef(sha);
+
+    return {
+      ref: sha,
+      label,
+      timestamp: new Date().toISOString(),
+      provider: "git",
+      metadata: { branch: this.currentBranch() },
+    };
+  }
+
+  async diff(from: StateRef): Promise<WorkspaceChanges> {
+    const ref = resolveRef(from);
+
+    // --name-only for file list
+    const nameOnly = this.git("diff", "--name-only", `${ref}..HEAD`);
+    const files = nameOnly.ok ? nameOnly.stdout.split("\n").filter(Boolean) : [];
+
+    // --stat for summary
+    const stat = this.git("diff", "--stat", `${ref}..HEAD`);
+    const summary = stat.ok ? stat.stdout : `${files.length} file(s) changed`;
+
+    // full diff for details (truncate if huge)
+    const full = this.git("diff", `${ref}..HEAD`);
+    const details = full.ok ? full.stdout.slice(0, 10_000) : undefined;
+
+    return { summary, files, details };
+  }
+
+  async baseline(): Promise<WorkspaceState> {
+    const remoteRef = `${this.remote}/${this.baseBranch}`;
+    validateRef(remoteRef);
+
+    // Fetch from origin
+    const fetch = this.git("fetch", this.remote, this.baseBranch);
+    if (!fetch.ok) {
+      const msg = `Could not fetch baseline (${remoteRef}): ${fetch.stderr}`;
+      if (this.failureMode === "hard") {
+        throw new Error(msg);
+      }
+      // warn mode: proceed with last known state
+      console.warn(`[workspace] ⚠️ ${msg} — proceeding with current state`);
+      const sha = this.headSha();
+      this.registerRef(sha);
+      return {
+        ref: sha,
+        label: `fallback-current-${sha.slice(0, 7)}`,
+        timestamp: new Date().toISOString(),
+        provider: "git",
+        metadata: { fallback: true, fetchError: fetch.stderr },
+      };
+    }
+
+    // Resolve the remote ref SHA
+    const sha = this.gitOrThrow("rev-parse", remoteRef);
+    this.registerRef(sha);
+
+    return {
+      ref: sha,
+      label: `baseline-${remoteRef}`,
+      timestamp: new Date().toISOString(),
+      provider: "git",
+      metadata: { remote: this.remote, baseBranch: this.baseBranch },
+    };
+  }
+}


### PR DESCRIPTION
## OPS-47 Phase 1 — Workspace Lifecycle Management

### New: `packages/cli/src/utils/workspace-provider.ts` (280 lines)
- `WorkspaceProvider` interface: `snapshot()`, `reset()`, `checkpoint()`, `diff()`, `baseline()`
- `GitWorkspaceProvider` implementation:
  - All git ops use `spawnSync` with `shell: false` + array args (S47-A)
  - Ref validation: `/^[a-zA-Z0-9._\/-]+$/` — rejects injection attempts (S47-A)
  - Auto-stash uncommitted work before `reset()`
  - `failureMode: 'warn' | 'hard'` for `baseline()` failures (S47-B)
  - Agent-scoped state only — no cross-agent refs (S47-C)
  - `reset()` failure → always throws (Kern: non-deterministic state is worse than blocked)

### New: `packages/cli/src/utils/agent-lifecycle.ts` (204 lines)
Extracted shared Flair hooks — runtime-agnostic:
- `bootContext()` — soul bootstrap + search past experience
- `searchPastExperience()` — queries Flair, returns formatted block or empty string
- `writeTaskMemory()` — structured JSON memory writes (completion/failure)
- Re-exports `catchUpTopics`

Both `EventLoop` and `runClaudeCodeRuntime` now call these instead of inline code.

### Modified: `packages/cli/src/utils/claude-code-runtime.ts`
- Uses `agent-lifecycle.ts` functions throughout
- Wires `GitWorkspaceProvider` on boot: stash → reset to baseline → fresh branch per task
- Per-task checkpoint on completion and failure

### Modified: `packages/cli/bin/tps.ts`
- Reads `workspaceProvider` config from `agent.yaml`
- Constructs `GitWorkspaceProvider` or falls back to null (no-op) for non-git workspaces

### Security
All three Sherlock findings (S47-A, B, C) and Kern's architecture note addressed.