### PR TITLE
fix(flair-client): remove unsupported limit param, warn on SearchMemories failure (ops-48)

### DIFF
--- a/packages/cli/src/utils/agent-lifecycle.ts
+++ b/packages/cli/src/utils/agent-lifecycle.ts
@@ -154,7 +154,8 @@ export async function searchPastExperience(
       .map(r => `- ${r.content?.slice(0, 200) ?? r.id}`)
       .join("\n");
     return `## Relevant Past Experience\n${experienceBlock}`;
-  } catch {
+  } catch (err: any) {
+    console.warn("[flair] SearchMemories failed (non-fatal):", err.message);
     return "";
   }
 }

--- a/packages/cli/src/utils/flair-client.ts
+++ b/packages/cli/src/utils/flair-client.ts
@@ -191,7 +191,7 @@ export class FlairClient {
   async listMemories(limit = 50): Promise<Memory[]> {
     return this.request<Memory[]>(
       "GET",
-      `/Memory/?agentId=${encodeURIComponent(this.agentId)}&limit=${limit}`,
+      `/Memory/?agentId=${encodeURIComponent(this.agentId)}`,
     );
   }
 


### PR DESCRIPTION
## ops-48 — Flair Client Endpoint Fixes

### Root cause analysis

Tested both endpoints against localhost:9926 with Ed25519 auth:

**Bug 1: `listMemories()` → 404**
Harper REST doesn't support `?limit=N` as a query param — it expects only indexed attributes. Removed the limit param from the URL. Results are returned without server-side pagination for now.

**Bug 2: `search()` → 400 (silent)**
`POST /SearchMemories/` hits Harper's table-level validation before reaching the custom resource handler — returns 400 with Memory table field requirements. This is a Flair-side routing issue (class name `SearchMemories` conflicts with table validation layer). The TPS client cannot fix this unilaterally — needs a Flair repo change.

### Changes

- `flair-client.ts`: removed `&limit=${limit}` from `listMemories()` URL
- `agent-lifecycle.ts`: replaced silent `catch {}` with `console.warn` — search failures now visible in session log

### Flair fix needed (separate PR in flair repo)
The `SearchMemories` custom resource class needs to be renamed or the Harper routing configured to not intercept it with table validation. Until then, past experience search silently no-ops but logs a warning.