### PR TITLE
fix(agent-lifecycle): MEMORY.md fallback when Flair search unavailable

### DIFF
--- a/packages/cli/src/utils/agent-lifecycle.ts
+++ b/packages/cli/src/utils/agent-lifecycle.ts
@@ -142,22 +142,37 @@ Always commit your work before mailing ${supervisor}:
 export async function searchPastExperience(
   flair: FlairClient,
   taskDescription: string,
+  workspacePath?: string,
 ): Promise<string> {
+  // Try Flair search first
   try {
     const flairOnline = await flair.ping();
-    if (!flairOnline) return "";
-
-    const searchResults = await flair.search(taskDescription.slice(0, 200), 5);
-    if (searchResults.length === 0) return "";
-
-    const experienceBlock = searchResults
-      .map(r => `- ${r.content?.slice(0, 200) ?? r.id}`)
-      .join("\n");
-    return `## Relevant Past Experience\n${experienceBlock}`;
+    if (flairOnline) {
+      const searchResults = await flair.search(taskDescription.slice(0, 200), 5);
+      if (searchResults.length > 0) {
+        const experienceBlock = searchResults
+          .map(r => `- ${r.content?.slice(0, 200) ?? r.id}`)
+          .join("\n");
+        return `## Relevant Past Experience\n${experienceBlock}`;
+      }
+    }
   } catch (err: any) {
-    console.warn("[flair] SearchMemories failed (non-fatal):", err.message);
-    return "";
+    console.warn("[flair] search failed (non-fatal):", err.message);
   }
+
+  // Fallback: read MEMORY.md from workspace
+  if (workspacePath) {
+    const memPath = join(workspacePath, "MEMORY.md");
+    if (existsSync(memPath)) {
+      const content = readFileSync(memPath, "utf-8").trim();
+      if (content) {
+        console.warn("[flair] Using MEMORY.md fallback for past experience");
+        return `## Past Experience (from MEMORY.md)\n${content.slice(0, 3000)}`;
+      }
+    }
+  }
+
+  return "";
 }
 
 // ── Task memory writes ─────────────────────────────────────────────────────

--- a/packages/cli/src/utils/claude-code-runtime.ts
+++ b/packages/cli/src/utils/claude-code-runtime.ts
@@ -143,7 +143,7 @@ async function buildSystemPrompt(
   );
 
   // Append past experience search
-  const experience = await searchPastExperience(flair, message.body);
+  const experience = await searchPastExperience(flair, message.body, workspace);
   if (experience) {
     return systemPrompt + "\n\n" + experience;
   }


### PR DESCRIPTION
## Problem
When Flair search fails (endpoint down, misconfigured, zero results), agents boot with no past experience context — causing amnesia between sessions.

## Fix
`searchPastExperience()` now has two-tier fallback:
1. **Flair search** (primary) — semantic search via `/FindMemories/`
2. **MEMORY.md** (fallback) — reads workspace `MEMORY.md` if Flair returns nothing

The fallback logs a warning so it's visible in session logs, and includes up to 3000 chars of MEMORY.md content in the system prompt under `## Past Experience (from MEMORY.md)`.

## Caller change
`claude-code-runtime.ts`: passes `workspace` path to `searchPastExperience()` so the fallback can locate `MEMORY.md`.