### PR TITLE
feat: Codex CLI runtime (ChatGPT OAuth, no API key)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -276,7 +276,8 @@ async function main() {
           const message = msgIdx >= 0 ? process.argv.slice(msgIdx + 1).join(" ") : undefined;
           await runAgent({ action: "run", config: configPath, id: agentId, message });
         } else if (action === "start") {
-          if (process.argv.includes("--runtime") && process.argv[process.argv.indexOf("--runtime") + 1] === "claude-code") {
+          const runtimeArg = process.argv.includes("--runtime") ? process.argv[process.argv.indexOf("--runtime") + 1] : undefined;
+          if (runtimeArg === "claude-code" || runtimeArg === "codex") {
             // Claude Code CLI runtime — OAuth, no TPS proxy needed
             const { join } = await import("node:path");
             const { homedir } = await import("node:os");
@@ -314,19 +315,34 @@ async function main() {
               }
             }
 
-            const { runClaudeCodeRuntime } = await import("../src/utils/claude-code-runtime.js");
-            await runClaudeCodeRuntime({
-              agentId: agentId!,
-              workspace: agentWorkspace,
-              mailDir: agentCfg.mailDir ?? join(homedir(), ".tps", "mail"),
-              model: agentCfg.llm?.model,
-              allowedTools: ["Bash", "Read", "Write", "Edit"],
-              extraDirs: [join(homedir(), ".tps", "mail", agentId!), join(homedir(), "ops", "tps")],
-              taskTimeoutMs: agentCfg.taskTimeoutMs,
-              flairUrl: agentCfg.flair?.url ?? process.env.FLAIR_URL,
-              flairKeyPath: agentCfg.flair?.keyPath,
-              workspaceProvider,
-            });
+            if (runtimeArg === "codex") {
+              const { runCodexRuntime } = await import("../src/utils/codex-runtime.js");
+              await runCodexRuntime({
+                agentId: agentId!,
+                workspace: agentWorkspace,
+                mailDir: agentCfg.mailDir ?? join(homedir(), ".tps", "mail"),
+                model: agentCfg.llm?.model ?? "gpt-4.1",
+                extraDirs: [join(homedir(), ".tps", "mail", agentId!), join(homedir(), "ops", "tps")],
+                taskTimeoutMs: agentCfg.taskTimeoutMs,
+                flairUrl: agentCfg.flair?.url ?? process.env.FLAIR_URL,
+                flairKeyPath: agentCfg.flair?.keyPath,
+                workspaceProvider,
+              });
+            } else {
+              const { runClaudeCodeRuntime } = await import("../src/utils/claude-code-runtime.js");
+              await runClaudeCodeRuntime({
+                agentId: agentId!,
+                workspace: agentWorkspace,
+                mailDir: agentCfg.mailDir ?? join(homedir(), ".tps", "mail"),
+                model: agentCfg.llm?.model,
+                allowedTools: ["Bash", "Read", "Write", "Edit"],
+                extraDirs: [join(homedir(), ".tps", "mail", agentId!), join(homedir(), "ops", "tps")],
+                taskTimeoutMs: agentCfg.taskTimeoutMs,
+                flairUrl: agentCfg.flair?.url ?? process.env.FLAIR_URL,
+                flairKeyPath: agentCfg.flair?.keyPath,
+                workspaceProvider,
+              });
+            }
           } else {
             await runAgent({ action: "start", config: configPath, id: agentId, sandbox: process.argv.includes("--sandbox"), sandboxed: process.argv.includes("--sandboxed") });
           }

--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -1,0 +1,265 @@
+/**
+ * codex-runtime.ts — Agent runtime backed by the Codex CLI (codex exec --json).
+ * Uses ChatGPT OAuth credentials; no OpenAI API key required.
+ * Same interface as claude-code-runtime.ts.
+ */
+
+import { spawn } from "node:child_process";
+import {
+  readFileSync, existsSync, mkdirSync, readdirSync,
+  renameSync, writeFileSync, appendFileSync, createWriteStream,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { FlairClient } from "./flair-client.js";
+import {
+  snapshotSoulToDisk,
+  bootContext,
+  searchPastExperience,
+  writeTaskMemory,
+  catchUpTopics,
+  onBoot,
+  onTaskStart,
+  onTaskComplete,
+  onTaskFailure,
+} from "./agent-lifecycle.js";
+import type { WorkspaceProvider } from "./workspace-provider.js";
+
+const FLAIR_SNAPSHOT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export interface CodexRuntimeConfig {
+  agentId: string;
+  workspace: string;
+  mailDir: string;
+  model?: string;
+  sandboxMode?: "read-only" | "workspace-write" | "danger-full-access";
+  extraDirs?: string[];
+  supervisorId?: string;
+  taskTimeoutMs?: number;
+  sessionLogPath?: string;
+  flairUrl?: string;
+  flairKeyPath?: string;
+  workspaceProvider?: WorkspaceProvider;
+}
+
+interface MailMessage {
+  id: string;
+  from: string;
+  to: string;
+  body: string;
+  timestamp: string;
+}
+
+function getMailPaths(mailDir: string, agentId: string) {
+  const root = join(mailDir, agentId);
+  const fresh = join(root, "new");
+  const cur = join(root, "cur");
+  const tmp = join(root, "tmp");
+  const outbox = join(root, "outbox");
+  for (const d of [fresh, cur, tmp, outbox]) mkdirSync(d, { recursive: true });
+  return { fresh, cur, tmp, outbox };
+}
+
+function checkNewMail(mailDir: string, agentId: string): MailMessage[] {
+  const { fresh, cur } = getMailPaths(mailDir, agentId);
+  const files = readdirSync(fresh).filter(f => f.endsWith(".json") && !f.startsWith("."));
+  const messages: MailMessage[] = [];
+  for (const file of files) {
+    const src = join(fresh, file);
+    const dst = join(cur, file);
+    try {
+      const msg = JSON.parse(readFileSync(src, "utf-8")) as MailMessage;
+      renameSync(src, dst);
+      messages.push(msg);
+    } catch {}
+  }
+  return messages;
+}
+
+function sendMail(mailDir: string, from: string, to: string, body: string): void {
+  const { fresh: recipientFresh, tmp: recipientTmp } = getMailPaths(mailDir, to);
+  const id = randomUUID();
+  const ts = new Date().toISOString();
+  const safeTs = ts.replace(/[:.]/g, "-");
+  const filename = `${safeTs}-${id}.json`;
+  const msg: MailMessage = { id, from, to, body, timestamp: ts };
+  const tmpPath = join(recipientTmp, filename);
+  const newPath = join(recipientFresh, filename);
+  writeFileSync(tmpPath, JSON.stringify(msg, null, 2), "utf-8");
+  renameSync(tmpPath, newPath);
+}
+
+async function buildSystemPrompt(
+  message: MailMessage,
+  config: CodexRuntimeConfig,
+): Promise<string> {
+  const { agentId, workspace, extraDirs, supervisorId, flairUrl, flairKeyPath } = config;
+  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath });
+  const allowedTools = ["Bash", "Read", "Write", "Edit"];
+  const { systemPrompt } = await bootContext(
+    flair, agentId, message.body.slice(0, 100), workspace,
+    { allowedTools, supervisorId },
+  );
+  const experience = await searchPastExperience(flair, message.body, workspace);
+  return experience ? systemPrompt + "\n\n" + experience : systemPrompt;
+}
+
+async function runCodex(
+  message: MailMessage,
+  config: CodexRuntimeConfig,
+  taskTimeoutMs: number,
+): Promise<string> {
+  const systemPrompt = await buildSystemPrompt(message, config);
+  const model = config.model ?? "gpt-4.1";
+  const sandboxMode = config.sandboxMode ?? "workspace-write";
+
+  const prompt = [systemPrompt, "", `[Mail from: ${message.from}]`, message.body].join("\n");
+
+  const args = [
+    "exec", "--json", "--ephemeral",
+    "--model", model,
+    "--sandbox", sandboxMode,
+    "--cd", config.workspace,
+    "-",
+  ];
+  for (const dir of config.extraDirs ?? []) args.push("--add-dir", dir);
+
+  const logPath = config.sessionLogPath ?? join(homedir(), ".tps", "agents", config.agentId, "session.log");
+  appendFileSync(logPath, `\n${"=".repeat(60)}\n[${new Date().toISOString()}] Task from ${message.from} (codex)\n${"=".repeat(60)}\n`, "utf-8");
+  const logStream = createWriteStream(logPath, { flags: "a" });
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn("codex", args, { cwd: config.workspace, env: process.env });
+    proc.stdin.write(prompt);
+    proc.stdin.end();
+
+    let resultMessages: string[] = [];
+    let turnCount = 0;
+    let stderr = "";
+    let buf = "";
+
+    proc.stdout.on("data", (d: Buffer) => {
+      logStream.write(d);
+      buf += d.toString();
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line) as Record<string, unknown>;
+          const item = event.item as Record<string, unknown> | undefined;
+          if (event.type === "item.completed" && item) {
+            if (item.type === "agent_message" && typeof item.text === "string") {
+              resultMessages.push(item.text);
+            } else if (item.type === "command_execution") {
+              turnCount++;
+              console.log(`[${config.agentId}] turn ${turnCount}: exec(${String(item.command ?? "").slice(0, 80)}) → ${item.exit_code}`);
+            }
+          } else if (event.type === "turn.completed") {
+            const u = event.usage as Record<string, number> | undefined;
+            if (u) console.log(`[${config.agentId}] tokens: in=${u.input_tokens} out=${u.output_tokens}`);
+          }
+        } catch {}
+      }
+    });
+
+    proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); logStream.write(d); });
+
+    const timeout = setTimeout(() => proc.kill("SIGTERM"), taskTimeoutMs);
+    proc.on("close", (code) => {
+      clearTimeout(timeout);
+      logStream.end();
+      const resultText = resultMessages.join("\n\n").trim();
+      if (resultText) {
+        resolve(resultText);
+      } else if (code !== 0) {
+        reject(new Error(`codex exited ${code}: ${stderr.slice(0, 500)}`));
+      } else {
+        reject(new Error("codex exited 0 with no agent_message output"));
+      }
+    });
+    proc.on("error", reject);
+  });
+}
+
+export async function runCodexRuntime(config: CodexRuntimeConfig): Promise<void> {
+  const { agentId, mailDir, workspace, flairUrl, flairKeyPath, workspaceProvider } = config;
+  writeFileSync(join(workspace, ".tps-agent.pid"), `${process.pid}\n`, "utf-8");
+  console.log(`[${agentId}] Codex runtime started. Polling ${mailDir}/${agentId}/new`);
+
+  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath });
+  const flairOnline = await flair.ping();
+  if (flairOnline) {
+    console.log(`[${agentId}] Flair online — snapshotting soul to disk`);
+    await snapshotSoulToDisk(flair, agentId);
+  } else {
+    const fallback = join(homedir(), ".tps", "agents", agentId, "fallback", "SOUL.md");
+    console.warn(`[${agentId}] ⚠️  Flair offline. Fallback: ${existsSync(fallback) ? fallback : "NONE"}`);
+  }
+
+  try {
+    const caught = catchUpTopics(agentId);
+    if (caught > 0) console.log(`[${agentId}] Caught up ${caught} missed topic message(s)`);
+  } catch (err: any) {
+    console.warn(`[${agentId}] Topic catch-up failed: ${err.message}`);
+  }
+
+  if (workspaceProvider) {
+    try {
+      const { lastCheckpoint } = await onBoot(workspaceProvider, flair, agentId);
+      if (lastCheckpoint) console.log(`[${agentId}] Resumed from: ${lastCheckpoint.label ?? lastCheckpoint.ref}`);
+    } catch (err: any) {
+      console.warn(`[${agentId}] Boot lifecycle failed (non-fatal): ${err.message}`);
+    }
+    try {
+      const base = await workspaceProvider.baseline();
+      await workspaceProvider.reset(base);
+      console.log(`[${agentId}] Workspace reset to baseline: ${base.label ?? base.ref.slice(0, 7)}`);
+    } catch (err: any) {
+      console.error(`[${agentId}] Workspace baseline reset failed: ${err.message}`);
+      throw err;
+    }
+  }
+
+  let lastSnapshot = Date.now();
+  while (true) {
+    if (Date.now() - lastSnapshot > FLAIR_SNAPSHOT_INTERVAL_MS && await flair.ping()) {
+      await snapshotSoulToDisk(flair, agentId);
+      lastSnapshot = Date.now();
+    }
+
+    for (const msg of checkNewMail(mailDir, agentId)) {
+      console.log(`[${agentId}] Processing mail from ${msg.from}: ${msg.body.slice(0, 60)}...`);
+      let preTaskState;
+      if (workspaceProvider) {
+        try { preTaskState = await onTaskStart(workspaceProvider, flair, msg.id); } catch (err: any) {
+          console.warn(`[${agentId}] Pre-task lifecycle failed: ${err.message}`);
+        }
+      }
+      try {
+        const result = await runCodex(msg, config, config.taskTimeoutMs ?? 30 * 60 * 1000);
+        const summary = result.length > 500 ? result.slice(0, 500) + "..." : result;
+        console.log(`[${agentId}] Task complete. Result length: ${result.length}`);
+        sendMail(mailDir, agentId, msg.from, `Task complete:\n\n${summary}`);
+        if (workspaceProvider && preTaskState) {
+          try { await onTaskComplete(workspaceProvider, flair, msg.id, preTaskState); } catch (err: any) {
+            console.warn(`[${agentId}] Post-task lifecycle failed: ${err.message}`);
+          }
+        } else {
+          await writeTaskMemory(flair, agentId, "completion", { task: msg.body, summary });
+        }
+      } catch (err: any) {
+        console.error(`[${agentId}] Task failed:`, err.message);
+        sendMail(mailDir, agentId, msg.from, `Task failed: ${err.message}`);
+        if (workspaceProvider && preTaskState) {
+          try { await onTaskFailure(workspaceProvider, flair, msg.id, preTaskState, err.message); } catch {}
+        } else {
+          await writeTaskMemory(flair, agentId, "failure", { task: msg.body, error: err.message });
+        }
+      }
+    }
+
+    await new Promise(r => setTimeout(r, 5000));
+  }
+}


### PR DESCRIPTION
Adds a Codex-backed agent runtime so Ember can use Nathan's ChatGPT subscription without an OpenAI API key.

## What
- **`codex-runtime.ts`** — mirrors `claude-code-runtime.ts` but spawns `codex exec --json` (headless Codex)
- **CLI dispatcher** — `tps agent start --runtime codex` reads `agent.yaml`, wires workspace provider, calls `runCodexRuntime()`

## Why
ChatGPT OAuth tokens (`auth_mode: chatgpt`) work with the Codex binary's internal endpoint, not `api.openai.com/v1/chat/completions`. The proxy approach hits 429 (insufficient_quota). The correct path is to delegate to Codex the same way we delegate to Claude Code.

## Codex exec JSONL format
```
{ type: "thread.started", thread_id }
{ type: "turn.started" }
{ type: "item.completed", item: { type: "agent_message", text } }
{ type: "item.completed", item: { type: "command_execution", command, exit_code, aggregated_output } }
{ type: "turn.completed", usage: { input_tokens, output_tokens } }
```

## Usage
Update agent.yaml: no change needed. Start with:
```bash
tps agent start --id ember --runtime codex
```

512 pass / 0 fail