### PR TITLE
feat(ops-62): refresh OpenAI token in poll loop every 30min

### DIFF
--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -263,7 +263,13 @@ export async function runCodexRuntime(config: CodexRuntimeConfig): Promise<void>
   }
 
   let lastSnapshot = Date.now();
+  let lastTokenRefresh = Date.now();
+  const TOKEN_REFRESH_INTERVAL_MS = 30 * 60 * 1000; // check every 30min
   while (true) {
+    if (Date.now() - lastTokenRefresh > TOKEN_REFRESH_INTERVAL_MS) {
+      await ensureFreshOpenAIToken(agentId);
+      lastTokenRefresh = Date.now();
+    }
     if (Date.now() - lastSnapshot > FLAIR_SNAPSHOT_INTERVAL_MS && await flair.ping()) {
       await snapshotSoulToDisk(flair, agentId);
       lastSnapshot = Date.now();


### PR DESCRIPTION
Follow-up to cli/#115 per Kern's review.\n\nAdds periodic token refresh in the mail poll loop (every 30min). Previously, boot-time refresh alone wasn't sufficient for multi-day Ember runs — token could expire between tasks.\n\nWith this: boot check + 30min poll = token stays fresh indefinitely.\n\n6 lines. 430/430 tests. Closes ops-62.