### PR TITLE
fix: task loop cursor race — look back 1hr on first boot

### DIFF
--- a/packages/cli/src/utils/flair-task-loop.ts
+++ b/packages/cli/src/utils/flair-task-loop.ts
@@ -42,7 +42,8 @@ function loadCursor(agentId: string): string {
     const data = JSON.parse(readFileSync(cursorPath(agentId), "utf-8"));
     if (data.since) return data.since;
   } catch {}
-  return new Date().toISOString();
+  // First boot: look back 1 hour to catch recently-assigned tasks
+  return new Date(Date.now() - 3_600_000).toISOString();
 }
 
 function saveCursor(agentId: string, since: string): void {


### PR DESCRIPTION
First boot defaulted cursor to `now()`, missing tasks published before agent start. Now looks back 1 hour. Found during live dogfood testing. 512/512 tests pass.