### PR TITLE
feat: tps agent decommission command (ops-49)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -230,14 +230,15 @@ async function main() {
     }
 
     case "agent": {
-      const validActions = ["run", "start", "health", "create", "list", "status"];
-      const action = rest[0] as "run" | "start" | "health" | "create" | "list" | "status" | undefined;
+      const validActions = ["run", "start", "health", "create", "list", "status", "decommission"];
+      const action = rest[0] as "run" | "start" | "health" | "create" | "list" | "status" | "decommission" | undefined;
       if (!action || !validActions.includes(action)) {
         console.error(
           "Usage:\n" +
           "  tps agent create --id <agent-id> [--name <name>] [--model <provider/model>] [--display-name <name>] [--soul-file <path>] [--no-seed]\n" +
           "  tps agent list [--json]\n" +
           "  tps agent status --id <agent-id> [--json]\n" +
+          "  tps agent decommission --id <agent-id> [--force]\n" +
           "  tps agent run --id <agent-id> --message <text>\n" +
           "  tps agent start --id <agent-id>\n" +
           "  tps agent health --id <agent-id>",
@@ -267,6 +268,13 @@ async function main() {
         await runAgent({ action: "list", json: cli.flags.json, flairUrl: getFlag("flair-url") });
       } else if (action === "status") {
         await runAgent({ action: "status", id: getFlag("id") ?? rest[1], json: cli.flags.json, flairUrl: getFlag("flair-url") });
+      } else if (action === "decommission") {
+        await runAgent({
+          action: "decommission",
+          id: getFlag("id") ?? rest[1],
+          flairUrl: getFlag("flair-url"),
+          force: cli.flags.force,
+        });
       } else {
         // run / start / health — support both --id and --config
         const configPath = getFlag("config");

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -13,13 +13,14 @@
 import { AgentRuntime, loadAgentConfig } from "@tpsdev-ai/agent";
 import { generateKeyPair, saveKeyPair, loadKeyPair } from "../utils/identity.js";
 import { createFlairClient } from "../utils/flair-client.js";
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { createInterface } from "node:readline/promises";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { findNono, runCommandUnderNono, isNonoStrict } from "../utils/nono.js";
 
 export interface AgentArgs {
-  action: "run" | "start" | "health" | "create" | "list" | "status";
+  action: "run" | "start" | "health" | "create" | "list" | "status" | "decommission";
   config?: string;
   message?: string;
   /** For create/list/status */
@@ -32,11 +33,42 @@ export interface AgentArgs {
   model?: string;
   flairUrl?: string;
   json?: boolean;
+  force?: boolean;
   sandbox?: boolean;
   /** Internal: set by re-exec under nono, skips re-wrapping */
   sandboxed?: boolean;
 }
 
+function archivePath(path: string, timestamp: string): string {
+  return `${path}.archived-${timestamp}`;
+}
+
+function archiveIfExists(path: string, timestamp: string): string | null {
+  if (!existsSync(path)) return null;
+  const archived = archivePath(path, timestamp);
+  renameSync(path, archived);
+  return archived;
+}
+
+async function confirmDecommission(agentId: string): Promise<void> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    console.error("Refusing to prompt without a TTY. Re-run with --force to skip confirmation.");
+    process.exit(1);
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(
+      `Decommission agent '${agentId}'? This archives local state and marks the Flair agent decommissioned. Type '${agentId}' to continue: `,
+    );
+    if (answer.trim() !== agentId) {
+      console.error("Decommission cancelled.");
+      process.exit(1);
+    }
+  } finally {
+    rl.close();
+  }
+}
 // ─── create ──────────────────────────────────────────────────────────────────
 
 async function loadSoulFile(filePath: string): Promise<Record<string, string>> {
@@ -309,6 +341,80 @@ async function agentStatus(args: AgentArgs): Promise<void> {
   }
 }
 
+async function decommissionAgent(args: AgentArgs): Promise<void> {
+  const id = args.id;
+  if (!id) {
+    console.error("Usage: tps agent decommission --id <agent-id> [--force]");
+    process.exit(1);
+  }
+
+  if (!args.force) {
+    await confirmDecommission(id);
+  }
+
+  const timestamp = Date.now().toString();
+  const flairUrl = args.flairUrl ?? process.env.FLAIR_URL ?? "http://127.0.0.1:9926";
+  const identityDir = join(homedir(), ".tps", "identity");
+  const mailDir = join(homedir(), ".tps", "mail");
+  const agentsDir = join(homedir(), ".tps", "agents");
+
+  const keyPath = join(identityDir, `${id}.key`);
+  const pubPath = join(identityDir, `${id}.pub`);
+  const mailPath = join(mailDir, id);
+  const agentConfigPath = join(agentsDir, id);
+
+  const summary: Array<{ label: string; result: string }> = [];
+
+  const flair = createFlairClient(id, flairUrl);
+  if (existsSync(keyPath)) {
+    try {
+      (flair as unknown as { loadKey: () => unknown }).loadKey();
+    } catch (error) {
+      throw new Error(`Failed to load Flair signing key for ${id}: ${String(error)}`);
+    }
+  }
+
+  const archivedKey = archiveIfExists(keyPath, timestamp);
+  summary.push({
+    label: "Identity key",
+    result: archivedKey ?? "not found",
+  });
+
+  const archivedPub = archiveIfExists(pubPath, timestamp);
+  summary.push({
+    label: "Identity public key",
+    result: archivedPub ?? "not found",
+  });
+
+  try {
+    const agent = await flair.getAgent(id);
+    if (agent) {
+      await flair.updateAgent(id, { status: "decommissioned" });
+      summary.push({ label: "Flair agent", result: `status=decommissioned (${flairUrl})` });
+    } else {
+      summary.push({ label: "Flair agent", result: "not found" });
+    }
+  } catch (error) {
+    throw new Error(`Failed to archive Flair identity for ${id}: ${String(error)}`);
+  }
+
+  const archivedMail = archiveIfExists(mailPath, timestamp);
+  summary.push({
+    label: "Mail dir",
+    result: archivedMail ?? "not found",
+  });
+
+  const archivedConfig = archiveIfExists(agentConfigPath, timestamp);
+  summary.push({
+    label: "Agent config",
+    result: archivedConfig ?? "not found",
+  });
+
+  console.log(`Decommissioned agent '${id}'.`);
+  for (const item of summary) {
+    console.log(`  ${item.label}: ${item.result}`);
+  }
+}
 // ─── Entry ───────────────────────────────────────────────────────────────────
 
 export async function runAgent(args: AgentArgs): Promise<void> {
@@ -321,6 +427,9 @@ export async function runAgent(args: AgentArgs): Promise<void> {
 
     case "status":
       return agentStatus(args);
+
+    case "decommission":
+      return decommissionAgent(args);
 
     case "run":
     case "start":

--- a/packages/cli/src/utils/flair-client.ts
+++ b/packages/cli/src/utils/flair-client.ts
@@ -98,6 +98,7 @@ export interface FlairAgent {
   id: string;
   name: string;
   publicKey: string;
+  status?: string;
   createdAt?: string;
 }
 

--- a/packages/cli/test/agent-decommission.test.ts
+++ b/packages/cli/test/agent-decommission.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+describe("tps agent decommission", () => {
+  let agentId: string;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    agentId = `ember-test-${Date.now()}`;
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    const home = homedir();
+    rmSync(join(home, ".tps", "identity", `${agentId}.key`), { force: true });
+    rmSync(join(home, ".tps", "identity", `${agentId}.pub`), { force: true });
+    for (const root of [join(home, ".tps", "identity"), join(home, ".tps", "mail"), join(home, ".tps", "agents")]) {
+      if (!existsSync(root)) continue;
+      for (const name of readdirSync(root)) {
+        if (name.startsWith(`${agentId}.`) || name.startsWith(`${agentId}.archived-`) || name.startsWith(`${agentId}.key.archived-`) || name.startsWith(`${agentId}.pub.archived-`) || name.startsWith(`${agentId}-`)) {
+          rmSync(join(root, name), { recursive: true, force: true });
+        }
+      }
+    }
+  });
+
+  test("archives local state and decommissions the Flair agent", async () => {
+    const { runAgent } = await import("../src/commands/agent.js");
+
+    const home = homedir();
+    const identityDir = join(home, ".tps", "identity");
+    const mailRoot = join(home, ".tps", "mail");
+    const agentsRoot = join(home, ".tps", "agents");
+    const mailDir = join(mailRoot, agentId);
+    const agentDir = join(agentsRoot, agentId);
+
+    mkdirSync(identityDir, { recursive: true });
+    mkdirSync(mailDir, { recursive: true });
+    mkdirSync(agentDir, { recursive: true });
+
+    writeFileSync(join(identityDir, `${agentId}.key`), Buffer.alloc(32, 7));
+    writeFileSync(join(identityDir, `${agentId}.pub`), Buffer.alloc(32, 9));
+    writeFileSync(join(mailDir, "message.txt"), "hello");
+    writeFileSync(join(agentDir, "agent.yaml"), `agentId: ${agentId}\n`);
+
+    const fetchMock = mock(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith(`/Agent/${agentId}`) && (!init || init.method === "GET")) {
+        return new Response(
+          JSON.stringify({
+            id: agentId,
+            name: agentId,
+            publicKey: "pub",
+            status: "active",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.endsWith(`/Agent/${agentId}`) && init?.method === "PUT") {
+        const body = JSON.parse(String(init.body));
+        expect(body.status).toBe("decommissioned");
+        return new Response("", { status: 204 });
+      }
+      throw new Error(`unexpected fetch: ${url} ${init?.method ?? "GET"}`);
+    });
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+    await runAgent({
+      action: "decommission",
+      id: agentId,
+      flairUrl: "http://127.0.0.1:9926",
+      force: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(existsSync(join(identityDir, `${agentId}.key`))).toBe(false);
+    expect(existsSync(join(identityDir, `${agentId}.pub`))).toBe(false);
+    expect(readdirSync(identityDir).some((name) => name.startsWith(`${agentId}.key.archived-`))).toBe(true);
+    expect(readdirSync(identityDir).some((name) => name.startsWith(`${agentId}.pub.archived-`))).toBe(true);
+    expect(readdirSync(mailRoot).some((name) => name.startsWith(`${agentId}.archived-`))).toBe(true);
+    expect(readdirSync(agentsRoot).some((name) => name.startsWith(`${agentId}.archived-`))).toBe(true);
+  });
+});


### PR DESCRIPTION
Ember implemented via Flair task loop (52 turns, 1.3M tokens). Archives keys, Flair identity, mail, config. Nothing deleted permanently. 513/513 tests pass.