### PR TITLE
feat: tps agent commit helper (ops-67)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -230,8 +230,8 @@ async function main() {
     }
 
     case "agent": {
-      const validActions = ["run", "start", "health", "create", "list", "status", "decommission"];
-      const action = rest[0] as "run" | "start" | "health" | "create" | "list" | "status" | "decommission" | undefined;
+      const validActions = ["run", "start", "health", "create", "list", "status", "decommission", "commit"];
+      const action = rest[0] as "run" | "start" | "health" | "create" | "list" | "status" | "decommission" | "commit" | undefined;
       if (!action || !validActions.includes(action)) {
         console.error(
           "Usage:\n" +
@@ -241,7 +241,9 @@ async function main() {
           "  tps agent decommission --id <agent-id> [--force]\n" +
           "  tps agent run --id <agent-id> --message <text>\n" +
           "  tps agent start --id <agent-id>\n" +
-          "  tps agent health --id <agent-id>",
+          "  tps agent health --id <agent-id>\n" +
+          "  tps agent decommission --id <agent-id> [--force]\n" +
+          "  tps agent commit --repo <path> --branch <name> --message <msg> --author <name> <email> [--path <f>] [--push] [--pr-title <t>]",
         );
         process.exit(1);
       }
@@ -274,6 +276,26 @@ async function main() {
           id: getFlag("id") ?? rest[1],
           flairUrl: getFlag("flair-url"),
           force: cli.flags.force,
+        });
+      } else if (action === "commit") {
+        // Inline helpers (getAuthor/getRepeatedFlags defined in else block below)
+        const authorIdx = process.argv.indexOf("--author");
+        const repoAuthorName = authorIdx >= 0 ? process.argv[authorIdx + 1] : undefined;
+        const repoAuthorEmail = authorIdx >= 0 ? process.argv[authorIdx + 2] : undefined;
+        const pathValues: string[] = [];
+        for (let i = 0; i < process.argv.length; i++) {
+          if (process.argv[i] === "--path" && process.argv[i + 1]) pathValues.push(process.argv[i + 1]!);
+        }
+        await runAgent({
+          action: "commit",
+          repo: getFlag("repo"),
+          branchName: getFlag("branch"),
+          commitMessage: getFlag("message"),
+          authorName: repoAuthorName,
+          authorEmail: repoAuthorEmail,
+          paths: pathValues,
+          push: process.argv.includes("--push"),
+          prTitle: getFlag("pr-title"),
         });
       } else {
         // run / start / health — support both --id and --config

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -20,7 +20,7 @@ import { join } from "node:path";
 import { findNono, runCommandUnderNono, isNonoStrict } from "../utils/nono.js";
 
 export interface AgentArgs {
-  action: "run" | "start" | "health" | "create" | "list" | "status" | "decommission";
+  action: "run" | "start" | "health" | "create" | "list" | "status" | "decommission" | "commit";
   config?: string;
   message?: string;
   /** For create/list/status */
@@ -34,6 +34,14 @@ export interface AgentArgs {
   flairUrl?: string;
   json?: boolean;
   force?: boolean;
+  repo?: string;
+  branchName?: string;
+  commitMessage?: string;
+  authorName?: string;
+  authorEmail?: string;
+  paths?: string[];
+  push?: boolean;
+  prTitle?: string;
   sandbox?: boolean;
   /** Internal: set by re-exec under nono, skips re-wrapping */
   sandboxed?: boolean;
@@ -431,6 +439,9 @@ export async function runAgent(args: AgentArgs): Promise<void> {
     case "decommission":
       return decommissionAgent(args);
 
+    case "commit":
+      return commitAgentChanges(args);
+
     case "run":
     case "start":
     case "health": {
@@ -522,5 +533,92 @@ export async function runAgent(args: AgentArgs): Promise<void> {
       console.error(`Unknown agent action: ${_}`);
       process.exit(1);
     }
+  }
+}
+
+// ─── agent commit ─────────────────────────────────────────────────────────────
+
+const SAFE_GIT_REF_RE = /^[a-zA-Z0-9._/-]+$/;
+const SIMPLE_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function failWith(message: string, exitCode = 1): never {
+  console.error(message);
+  process.exit(exitCode);
+}
+
+function isWithinDir(root: string, target: string): boolean {
+  const rel = require("node:path").relative(root, target);
+  return rel === "" || (!rel.startsWith("..") && !rel.startsWith("/"));
+}
+
+function runGit(args: string[], cwd: string): { ok: boolean; stdout: string; stderr: string; status: number } {
+  const { spawnSync } = require("node:child_process");
+  const r = spawnSync("git", args, { cwd, encoding: "utf-8" });
+  return { ok: r.status === 0, stdout: (r.stdout ?? "").trim(), stderr: (r.stderr ?? "").trim(), status: r.status ?? 1 };
+}
+
+function runGitOrFail(args: string[], cwd: string, label: string): string {
+  const r = runGit(args, cwd);
+  if (!r.ok) failWith(`${label} failed: ${r.stderr || r.stdout || `exit ${r.status}`}`);
+  return r.stdout;
+}
+
+async function commitAgentChanges(args: AgentArgs): Promise<void> {
+  const { repo, branchName, commitMessage, authorName, authorEmail, paths, push: doPush, prTitle } = args;
+
+  if (!repo || !branchName || !commitMessage || !authorName || !authorEmail) {
+    failWith("Usage: tps agent commit --repo <path> --branch <name> --message <msg> --author <name> <email> [--path <file>] [--push] [--pr-title <title>]");
+  }
+  if (!SIMPLE_EMAIL_RE.test(authorEmail!)) failWith(`Invalid author email: ${authorEmail}`);
+  if (branchName!.startsWith("-") || !SAFE_GIT_REF_RE.test(branchName!)) failWith(`Invalid branch name: ${branchName}`);
+
+  const { resolve: resolvePath, relative: relativePath } = require("node:path");
+  const { existsSync: exists } = require("node:fs");
+  const repoPath = resolvePath(repo!);
+  if (!exists(repoPath)) failWith(`Repository path not found: ${repoPath}`);
+  if (!repoPath.startsWith("/")) failWith("Repository path must be absolute.");
+  const gitCheck = runGit(["rev-parse", "--is-inside-work-tree"], repoPath);
+  if (!gitCheck.ok || gitCheck.stdout !== "true") failWith(`Not a git repository: ${repoPath}`);
+
+  // Create or checkout branch
+  const branchExists = runGit(["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`], repoPath).ok;
+  if (branchExists) {
+    runGitOrFail(["checkout", branchName!], repoPath, `checkout ${branchName}`);
+  } else {
+    runGitOrFail(["checkout", "-b", branchName!], repoPath, `create branch ${branchName}`);
+  }
+
+  // Stage changes
+  if (paths && paths.length > 0) {
+    const safePaths = paths.map((p) => {
+      const abs = resolvePath(repoPath, p);
+      if (!isWithinDir(repoPath, abs)) failWith(`Path escapes repo: ${p}`);
+      return relativePath(repoPath, abs) || ".";
+    });
+    runGitOrFail(["add", "--", ...safePaths], repoPath, "git add");
+  } else {
+    runGitOrFail(["add", "-A"], repoPath, "git add -A");
+  }
+
+  const diff = runGit(["diff", "--cached", "--quiet"], repoPath);
+  if (diff.status === 0) failWith("No changes staged for commit.");
+
+  runGitOrFail(["commit", "--author", `${authorName} <${authorEmail}>`, "-m", commitMessage!], repoPath, "git commit");
+  console.log(`Committed changes in ${repoPath} on branch ${branchName}.`);
+
+  if (!doPush) return;
+
+  runGitOrFail(["push", "-u", "origin", branchName!], repoPath, "git push");
+  console.log(`Pushed ${branchName} to origin.`);
+
+  // Open PR via gh-as
+  const agentHandle = authorEmail!.split("@")[0] ?? "";
+  const title = prTitle ?? commitMessage!;
+  const { spawnSync } = require("node:child_process");
+  const pr = spawnSync("gh-as", [agentHandle, "pr", "create", "--title", title, "--body", commitMessage!, "--head", branchName!], { cwd: repoPath, encoding: "utf-8" });
+  if (pr.status !== 0) {
+    console.warn(`PR creation failed: ${pr.stderr?.trim() ?? pr.stdout?.trim()}`);
+  } else {
+    console.log(`PR opened: ${pr.stdout?.trim()}`);
   }
 }

--- a/packages/cli/test/agent-commit.test.ts
+++ b/packages/cli/test/agent-commit.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const TPS_BIN = resolve(import.meta.dir, "../bin/tps.ts");
+const TMP_ROOT = resolve(import.meta.dir, "../.tmp-tests");
+
+function runCommand(cmd: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv) {
+  const result = spawnSync(cmd, args, {
+    cwd,
+    env,
+    encoding: "utf-8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`${cmd} ${args.join(" ")} failed:\n${result.stderr || result.stdout}`);
+  }
+  return (result.stdout ?? "").trim();
+}
+
+function initRepo(root: string): string {
+  const repo = join(root, "repo");
+  mkdirSync(repo, { recursive: true });
+  runCommand("git", ["init"], repo);
+  runCommand("git", ["checkout", "-b", "main"], repo);
+  runCommand("git", ["config", "user.name", "Test User"], repo);
+  runCommand("git", ["config", "user.email", "test@example.com"], repo);
+  writeFileSync(join(repo, "tracked.txt"), "base tracked\n");
+  writeFileSync(join(repo, "other.txt"), "base other\n");
+  runCommand("git", ["add", "-A"], repo);
+  runCommand("git", ["commit", "-m", "initial"], repo);
+  return repo;
+}
+
+mkdirSync(TMP_ROOT, { recursive: true });
+
+describe("tps agent commit", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+  test("creates a branch and commits only the requested paths", () => {
+    const root = mkdtempSync(join(TMP_ROOT, "agent-commit-"));
+    tempRoots.push(root);
+    const repo = initRepo(root);
+
+    writeFileSync(join(repo, "tracked.txt"), "changed tracked\n");
+    writeFileSync(join(repo, "other.txt"), "changed other\n");
+
+    const cleanEnv = Object.fromEntries(
+      Object.entries(process.env).filter(([k]) => !k.startsWith("GIT_"))
+    );
+    const result = spawnSync("bun", [
+      TPS_BIN,
+      "agent",
+      "commit",
+      "--repo", repo,
+      "--branch", "feat/path-scope",
+      "--message", "path scoped commit",
+      "--author", "Ember", "ember@tps.dev",
+      "--path", "tracked.txt",
+    ], {
+      cwd: repo,
+      encoding: "utf-8",
+      env: cleanEnv,
+    });
+
+    expect(result.status).toBe(0);
+    expect(runCommand("git", ["rev-parse", "--abbrev-ref", "HEAD"], repo)).toBe("feat/path-scope");
+    expect(runCommand("git", ["log", "-1", "--format=%an <%ae>|%s"], repo)).toBe("Ember <ember@tps.dev>|path scoped commit");
+    expect(runCommand("git", ["show", "--name-only", "--pretty=format:", "HEAD"], repo)).toBe("tracked.txt");
+    expect(runCommand("git", ["status", "--short"], repo)).toContain("M other.txt");
+  });
+
+  test("pushes the branch and opens a PR via gh-as", () => {
+    const root = mkdtempSync(join(TMP_ROOT, "agent-commit-"));
+    tempRoots.push(root);
+    const repo = initRepo(root);
+    const remote = join(root, "remote.git");
+    const binDir = join(root, "bin");
+    const ghLog = join(root, "gh-as.log");
+
+    runCommand("git", ["init", "--bare", remote], root);
+    runCommand("git", ["remote", "add", "origin", remote], repo);
+    runCommand("git", ["push", "-u", "origin", "main"], repo);
+
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(
+      join(binDir, "gh-as"),
+      `#!/bin/sh
+printf '%s\n' "$@" > "${ghLog}"
+`,
+    );
+    chmodSync(join(binDir, "gh-as"), 0o755);
+
+    writeFileSync(join(repo, "tracked.txt"), "push me\n");
+
+    const result = spawnSync("bun", [
+      TPS_BIN,
+      "agent",
+      "commit",
+      "--repo", repo,
+      "--branch", "feat/push-pr",
+      "--message", "ship push flow",
+      "--author", "Ember", "ember@tps.dev",
+      "--push",
+      "--pr-title", "feat: push flow",
+    ], {
+      cwd: repo,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(runCommand("git", ["--git-dir", remote, "rev-parse", "refs/heads/feat/push-pr"], root)).not.toHaveLength(0);
+    expect(readFileSync(ghLog, "utf-8").trim()).toBe(
+      [
+        "ember",
+        "pr",
+        "create",
+        "--title",
+        "feat: push flow",
+        "--body",
+        "ship push flow",
+        "--head",
+        "feat/push-pr",
+      ].join("\n"),
+    );
+  });
+});


### PR DESCRIPTION
Adds `tps agent commit` command for sandboxed agents to commit, push, and open PRs.

**Usage:**
```
tps agent commit --repo <path> --branch <name> --message <msg> --author <name> <email> [--path <file>] [--push] [--pr-title <title>]
```

**Features:**
- Branch creation/checkout
- Selective path staging (`--path`) or full staging
- Git ref and email validation
- Optional push + PR creation via `gh-as`
- Repo path safety checks

**Tests:** 2 new tests, 515/515 pass (0 fail)

Ember implemented (52 turns, codex runtime), Anvil integrated + resolved merge conflicts + fixed test isolation bug.

Closes ops-67.