### PR TITLE
feat: tps agent isolate command (ops-61)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -230,8 +230,8 @@ async function main() {
     }
 
     case "agent": {
-      const validActions = ["run", "start", "health", "create", "list", "status", "decommission", "commit"];
-      const action = rest[0] as "run" | "start" | "health" | "create" | "list" | "status" | "decommission" | "commit" | undefined;
+      const validActions = ["run", "start", "health", "create", "list", "status", "decommission", "commit", "isolate"];
+      const action = rest[0] as "run" | "start" | "health" | "create" | "list" | "status" | "decommission" | "commit" | "isolate" | undefined;
       if (!action || !validActions.includes(action)) {
         console.error(
           "Usage:\n" +
@@ -296,6 +296,13 @@ async function main() {
           paths: pathValues,
           push: process.argv.includes("--push"),
           prTitle: getFlag("pr-title"),
+        });
+      } else if (action === "isolate") {
+        const portArg = getFlag("port");
+        await runAgent({
+          action: "isolate",
+          id: getFlag("id") ?? rest[1],
+          port: portArg ? parseInt(portArg, 10) : undefined,
         });
       } else {
         // run / start / health — support both --id and --config

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -20,7 +20,7 @@ import { join } from "node:path";
 import { findNono, runCommandUnderNono, isNonoStrict } from "../utils/nono.js";
 
 export interface AgentArgs {
-  action: "run" | "start" | "health" | "create" | "list" | "status" | "decommission" | "commit";
+  action: "run" | "start" | "health" | "create" | "list" | "status" | "decommission" | "commit" | "isolate";
   config?: string;
   message?: string;
   /** For create/list/status */
@@ -34,6 +34,7 @@ export interface AgentArgs {
   flairUrl?: string;
   json?: boolean;
   force?: boolean;
+  port?: number;
   repo?: string;
   branchName?: string;
   commitMessage?: string;
@@ -442,6 +443,9 @@ export async function runAgent(args: AgentArgs): Promise<void> {
     case "commit":
       return commitAgentChanges(args);
 
+    case "isolate":
+      return isolateAgent(args);
+
     case "run":
     case "start":
     case "health": {
@@ -621,4 +625,66 @@ async function commitAgentChanges(args: AgentArgs): Promise<void> {
   } else {
     console.log(`PR opened: ${pr.stdout?.trim()}`);
   }
+}
+
+// ─── agent isolate ────────────────────────────────────────────────────────────
+
+async function isolateAgent(args: AgentArgs): Promise<void> {
+  const id = args.id;
+  if (!id) {
+    console.error("Usage: tps agent isolate --id <agent-id> [--port <gateway-port>]");
+    process.exit(1);
+  }
+
+  const ocHome = join(homedir(), `.openclaw-${id}`);
+  const srcJson = join(homedir(), ".openclaw", "openclaw.json");
+  const dstJson = join(ocHome, "openclaw.json");
+
+  if (!existsSync(srcJson)) {
+    console.error(`OpenClaw config not found at ${srcJson}`);
+    process.exit(1);
+  }
+
+  mkdirSync(ocHome, { recursive: true });
+
+  // Read source config
+  const src = JSON.parse(readFileSync(srcJson, "utf-8"));
+
+  // Extract just this agent's entry
+  const agentList: any[] = src.agents?.list ?? [];
+  const agentEntry = agentList.find((a: any) => a.id === id);
+  if (!agentEntry) {
+    console.error(`Agent '${id}' not found in OpenClaw config.`);
+    process.exit(1);
+  }
+
+  // Build isolated config — minimal subset, single agent
+  const port = args.port ?? 18800 + Math.floor(Math.random() * 100);
+  const isolated = {
+    meta: src.meta ?? {},
+    wizard: { completed: true },
+    secrets: {},
+    auth: {},
+    models: src.models ?? {},
+    agents: {
+      defaults: src.agents?.defaults ?? {},
+      list: [agentEntry],
+    },
+    bindings: {},
+    messages: {},
+    commands: {},
+    channels: src.channels ?? {},
+    gateway: { port },
+    plugins: src.plugins ?? {},
+  };
+
+  writeFileSync(dstJson, JSON.stringify(isolated, null, 2), "utf-8");
+
+  console.log(`\nAgent '${id}' isolated at: ${ocHome}`);
+  console.log(`Gateway port: ${port}`);
+  console.log(`\nTo start the isolated gateway:`);
+  console.log(`  OPENCLAW_HOME=${ocHome} openclaw gateway start`);
+  console.log(`\nAdd to ~/.tps/agents/${id}/agent.yaml:`);
+  console.log(`  openclawHome: ${ocHome}`);
+  console.log(`  openclawPort: ${port}`);
 }

--- a/packages/cli/test/agent-isolate.test.ts
+++ b/packages/cli/test/agent-isolate.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, rmSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+const TPS_BIN = resolve(import.meta.dir, "../bin/tps.ts");
+
+describe("tps agent isolate", () => {
+  const testDir = join(homedir(), ".openclaw-isolate-test");
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("errors when agent not found in openclaw.json", () => {
+    const result = spawnSync("bun", [TPS_BIN, "agent", "isolate", "--id", "nonexistent-agent-xyz"], {
+      encoding: "utf-8",
+      env: process.env,
+    });
+    expect(result.status).not.toBe(0);
+    expect((result.stderr ?? "") + (result.stdout ?? "")).toMatch(/not found|OpenClaw config not found/i);
+  });
+
+  test("errors when no --id provided", () => {
+    const result = spawnSync("bun", [TPS_BIN, "agent", "isolate"], {
+      encoding: "utf-8",
+      env: process.env,
+    });
+    expect(result.status).not.toBe(0);
+  });
+});


### PR DESCRIPTION
Implements Option A from ops-61 spec: per-agent OpenClaw profile isolation.

```
tps agent isolate --id ember --port 18791
```

Creates `~/.openclaw-ember/openclaw.json` with only Ember's agent config, a fresh gateway port, and outputs the `OPENCLAW_HOME` env var to use.

**Non-destructive**: does not touch the live gateway or shared config.
**Zero OpenClaw changes required**: pure OPENCLAW_HOME env var.

Nathan runs once per agent to provision isolation. Then:
```
OPENCLAW_HOME=~/.openclaw-ember openclaw gateway start
```

523/523 tests pass.