### PR TITLE
fix: pass HOME env to init test subprocess (Docker compat)

### DIFF
--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -21,7 +21,8 @@ afterEach(() => {
 describe("tps init", () => {
   test("scaffolds identity, config, and workspace", () => {
     const result = spawnSync("bun", [TPS_BIN, "init", "--id", TEST_ID], {
-      encoding: "utf-8", env: { ...process.env },
+      encoding: "utf-8",
+      env: { ...process.env, HOME },  // ensure subprocess uses same HOME
     });
     expect(result.status).toBe(0);
     expect(existsSync(join(HOME, ".tps", "identity", `${TEST_ID}.key`))).toBe(true);


### PR DESCRIPTION
The `tps init` test was failing in Docker because the parent process HOME differed from what the spawned CLI subprocess's `homedir()` returned. Explicitly passing `HOME` in the spawn env fixes the mismatch.

Fixes the Docker CI failure from cli/#126.