### PR TITLE
refactor: make keyPath required in FlairClient + createFlairClient (ops-74)

### DIFF
--- a/packages/cli/src/commands/memory-learn.ts
+++ b/packages/cli/src/commands/memory-learn.ts
@@ -8,7 +8,7 @@
  * consolidate <agentId> — review persistent memories for promote/archive/keep
  */
 
-import { createFlairClient } from "../utils/flair-client.js";
+import { createFlairClient, defaultFlairKeyPath } from "../utils/flair-client.js";
 
 export interface MemoryLearnArgs {
   action: "reflect" | "consolidate";
@@ -30,7 +30,7 @@ export interface MemoryLearnArgs {
 
 export async function runMemoryLearn(args: MemoryLearnArgs): Promise<void> {
   const flairUrl = args.flairUrl ?? process.env.FLAIR_URL ?? "http://127.0.0.1:9926";
-  const flair = createFlairClient(args.agentId, flairUrl, args.keyPath);
+  const flair = createFlairClient(args.agentId, flairUrl, args.keyPath ?? defaultFlairKeyPath(args.agentId));
 
   switch (args.action) {
     case "reflect": {

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -13,7 +13,7 @@
  *   search <agentId> <q>    Semantic search (excludes archived)
  */
 
-import { createFlairClient, type Memory } from "../utils/flair-client.js";
+import { createFlairClient, defaultFlairKeyPath, type Memory } from "../utils/flair-client.js";
 
 export interface MemoryArgs {
   action: "review" | "approve" | "reject" | "archive" | "unarchive" | "purge" | "list" | "show" | "search";
@@ -46,7 +46,7 @@ export async function runMemory(args: MemoryArgs): Promise<void> {
   // For governance ops (approve/reject/archive/purge) the admin authenticates as themselves
   // The agentId used for signing is the CLI operator's configured agent (default: from env)
   const operatorId = process.env.TPS_AGENT_ID ?? args.agentId ?? "admin";
-  const flair = createFlairClient(operatorId, flairUrl, args.keyPath);
+  const flair = createFlairClient(operatorId, flairUrl, args.keyPath ?? defaultFlairKeyPath(operatorId));
 
   switch (args.action) {
     case "review": {
@@ -143,7 +143,7 @@ export async function runMemory(args: MemoryArgs): Promise<void> {
         console.error("Usage: tps memory search <agentId> <query>");
         process.exit(1);
       }
-      const agentFlair = createFlairClient(args.agentId, flairUrl, args.keyPath);
+      const agentFlair = createFlairClient(args.agentId, flairUrl, args.keyPath ?? defaultFlairKeyPath(args.agentId));
       const results = await agentFlair.search(args.query, args.limit ?? 10);
       if (args.json) { console.log(JSON.stringify(results, null, 2)); break; }
       if (results.length === 0) { console.log("No results."); break; }

--- a/packages/cli/src/commands/roster.ts
+++ b/packages/cli/src/commands/roster.ts
@@ -1,7 +1,7 @@
 import { findOpenClawConfig, getAgentList, readOpenClawConfig, resolveConfigPath, resolveWorkspace, type OpenClawAgent } from "../utils/config.js";
 import { sanitizeIdentifier } from "../schema/sanitizer.js";
 import { getAgentInfo } from "../utils/agent-info.js";
-import { createFlairClient } from "../utils/flair-client.js";
+import { createFlairClient, defaultFlairKeyPath } from "../utils/flair-client.js";
 import { sendMail } from "../utils/mail-bridge.js";
 import { loadHostIdentityId } from "../utils/identity.js";
 import { homedir } from "node:os";
@@ -172,7 +172,7 @@ export async function runRoster(args: RosterArgs): Promise<void> {
         process.exit(1);
       }
       const invitedBy = await resolveInviterId();
-      const flair = createFlairClient(invitedBy, args.flairUrl, args.keyPath);
+      const flair = createFlairClient(invitedBy, args.flairUrl, args.keyPath ?? defaultFlairKeyPath(invitedBy));
       try {
         await flair.request("GET", `/Identity/${encodeURIComponent(args.agent)}`);
       } catch (error) {

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -1,5 +1,3 @@
-import { homedir } from "node:os";
-import { join } from "node:path";
 /**
  * tps skill — Skill governance lifecycle commands (ops-31.4)
  *
@@ -7,7 +5,7 @@ import { join } from "node:path";
  * Skills are knowledge packages — not executable code.
  */
 import { readFileSync } from "node:fs";
-import { createFlairClient } from "../utils/flair-client.js";
+import { createFlairClient, defaultFlairKeyPath } from "../utils/flair-client.js";
 
 export interface SkillArgs {
   action: "list" | "register" | "scan" | "revoke" | "show";
@@ -43,7 +41,7 @@ async function listSkills(args: SkillArgs): Promise<void> {
     process.exit(1);
   }
 
-  const flair = createFlairClient(agentId, args.flairUrl, join(homedir(), ".tps", "identity", `${agentId}.key`));
+  const flair = createFlairClient(agentId, args.flairUrl, defaultFlairKeyPath(agentId));
   const skills = await flair.listSkills(agentId);
 
   if (args.json) {
@@ -92,7 +90,7 @@ async function registerSkill(args: SkillArgs): Promise<void> {
     process.exit(1);
   }
 
-  const flair = createFlairClient(agent, args.flairUrl, join(homedir(), ".tps", "identity", `${agent}.key`));
+  const flair = createFlairClient(agent, args.flairUrl, defaultFlairKeyPath(agent));
 
   // Auto-scan before registration
   console.log("Scanning skill content...");
@@ -152,7 +150,7 @@ async function scanSkill(args: SkillArgs): Promise<void> {
 
   // Use a default agent ID for scan-only (read-only operation)
   const agentId = args.agent ?? process.env.TPS_AGENT_ID ?? "nathan";
-  const flair = createFlairClient(agentId, args.flairUrl, join(homedir(), ".tps", "identity", `${agentId}.key`));
+  const flair = createFlairClient(agentId, args.flairUrl, defaultFlairKeyPath(agentId));
   const result = await flair.scanSkill(content);
 
   if (args.json) {
@@ -179,7 +177,7 @@ async function revokeSkill(args: SkillArgs): Promise<void> {
     process.exit(1);
   }
 
-  const flair = createFlairClient(agent, args.flairUrl, join(homedir(), ".tps", "identity", `${agent}.key`));
+  const flair = createFlairClient(agent, args.flairUrl, defaultFlairKeyPath(agent));
   await flair.revokeSkill(agent, name);
   console.log(`Skill '${name}' revoked from ${agent}. Takes effect on next bootstrap.`);
 }
@@ -191,7 +189,7 @@ async function showSkill(args: SkillArgs): Promise<void> {
     process.exit(1);
   }
 
-  const flair = createFlairClient(agent, args.flairUrl, join(homedir(), ".tps", "identity", `${agent}.key`));
+  const flair = createFlairClient(agent, args.flairUrl, defaultFlairKeyPath(agent));
   const skills = await flair.listSkills(agent);
   const skill = skills.find((s) => s.value === name);
 

--- a/packages/cli/src/commands/soul.ts
+++ b/packages/cli/src/commands/soul.ts
@@ -8,7 +8,7 @@
  *   diff <agentId> --file <f>  Diff current soul against a file
  */
 
-import { createFlairClient } from "../utils/flair-client.js";
+import { createFlairClient, defaultFlairKeyPath } from "../utils/flair-client.js";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -49,7 +49,7 @@ function textToEntries(text: string): Array<{ key: string; value: string }> {
 export async function runSoul(args: SoulArgs): Promise<void> {
   const flairUrl = args.flairUrl ?? process.env.FLAIR_URL ?? "http://127.0.0.1:9926";
   const actorId = args.asAgent ?? args.agentId;
-  const flair = createFlairClient(actorId, flairUrl, args.keyPath);
+  const flair = createFlairClient(actorId, flairUrl, args.keyPath ?? defaultFlairKeyPath(actorId));
 
   switch (args.action) {
     case "show": {

--- a/packages/cli/src/utils/claude-code-runtime.ts
+++ b/packages/cli/src/utils/claude-code-runtime.ts
@@ -38,7 +38,7 @@ import {
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
-import { FlairClient } from "./flair-client.js";
+import { FlairClient, defaultFlairKeyPath } from "./flair-client.js";
 import {
   snapshotSoulToDisk,
   bootContext,
@@ -139,7 +139,7 @@ async function buildSystemPrompt(
 ): Promise<string> {
   const { agentId, workspace, allowedTools, supervisorId, flairUrl, flairKeyPath } = config;
 
-  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath });
+  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath ?? defaultFlairKeyPath(agentId) });
 
   const { systemPrompt, identitySource } = await bootContext(
     flair, agentId, message.body.slice(0, 100), workspace,
@@ -279,7 +279,7 @@ export async function runClaudeCodeRuntime(config: ClaudeCodeConfig): Promise<vo
 
   console.log(`[${agentId}] Claude Code runtime started. Polling ${mailDir}/${agentId}/new`);
 
-  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath });
+  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath ?? defaultFlairKeyPath(agentId) });
 
   // Initial Flair health check + snapshot
   const flairOnline = await flair.ping();

--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -12,7 +12,7 @@ import {
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
-import { FlairClient } from "./flair-client.js";
+import { FlairClient, defaultFlairKeyPath } from "./flair-client.js";
 import {
   snapshotSoulToDisk,
   bootContext,
@@ -153,7 +153,7 @@ async function buildSystemPrompt(
   config: CodexRuntimeConfig,
 ): Promise<string> {
   const { agentId, workspace, extraDirs, supervisorId, flairUrl, flairKeyPath } = config;
-  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath });
+  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath ?? defaultFlairKeyPath(agentId) });
   const allowedTools = ["Bash", "Read", "Write", "Edit"];
   const { systemPrompt } = await bootContext(
     flair, agentId, message.body.slice(0, 100), workspace,
@@ -351,7 +351,7 @@ export async function runCodexRuntime(config: CodexRuntimeConfig): Promise<void>
 
   await ensureFreshOpenAIToken(agentId);
 
-  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath });
+  const flair = new FlairClient({ baseUrl: flairUrl, agentId, keyPath: flairKeyPath ?? defaultFlairKeyPath(agentId) });
 
   // Mark offline on clean shutdown
   const markOffline = () => {

--- a/packages/cli/src/utils/flair-client.ts
+++ b/packages/cli/src/utils/flair-client.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 export interface FlairConfig {
   baseUrl?: string;
   agentId: string;
-  keyPath?: string;
+  keyPath: string;
 }
 
 export interface Memory {
@@ -99,6 +99,7 @@ export interface FlairAgent {
   name: string;
   publicKey: string;
   status?: string;
+  lastHeartbeat?: string;
   createdAt?: string;
 }
 
@@ -135,9 +136,7 @@ export class FlairClient {
   constructor(config: FlairConfig) {
     this.baseUrl = (config.baseUrl ?? "http://127.0.0.1:9926").replace(/\/$/, "");
     this.agentId = config.agentId;
-    this.keyPath =
-      config.keyPath ??
-      join(homedir(), ".tps", "identity", `${config.agentId}.key`);
+    this.keyPath = config.keyPath;
   }
 
   private loadKey(): ReturnType<typeof createPrivateKey> {
@@ -238,6 +237,14 @@ export class FlairClient {
       return await this.request<FlairAgent>("GET", `/Agent/${id ?? this.agentId}`);
     } catch {
       return null;
+    }
+  }
+
+  async listAgents(): Promise<FlairAgent[]> {
+    try {
+      return await this.request<FlairAgent[]>("GET", "/Agent/");
+    } catch {
+      return [];
     }
   }
 
@@ -595,10 +602,14 @@ export class FlairClient {
   }
 }
 
+export function defaultFlairKeyPath(agentId: string): string {
+  return join(homedir(), ".tps", "identity", `${agentId}.key`);
+}
+
 export function createFlairClient(
   agentId: string,
-  baseUrl?: string,
-  keyPath?: string,
+  baseUrl: string | undefined,
+  keyPath: string,
 ): FlairClient {
   return new FlairClient({
     agentId,


### PR DESCRIPTION
The lint rule caught violations. Now TypeScript enforces it.

**Changes in `flair-client.ts`:**
- `FlairClient` config: `keyPath` required (was optional)
- `createFlairClient()`: `keyPath` required 3rd arg (was optional)
- Removed `homedir()` fallback from constructor
- Added `defaultFlairKeyPath(agentId)` helper for callers that derive it

**Fixed callers:**
- `roster.ts`: `args.keyPath ?? defaultFlairKeyPath(invitedBy)`
- `codex-runtime.ts`, `claude-code-runtime.ts`: `flairKeyPath ?? defaultFlairKeyPath(agentId)`
- `memory.ts`, `memory-learn.ts`, `skill.ts`, `soul.ts`: Ember threaded keyPath through

Ember implemented (ops-74), Anvil integrated. lint ✅ 561/561 tests pass.