### PR TITLE
fix: bridge seed race — 30s lookback window

### DIFF
--- a/packages/cli/src/bridge/discord-adapter.ts
+++ b/packages/cli/src/bridge/discord-adapter.ts
@@ -49,11 +49,11 @@ export class DiscordAdapter implements BridgeAdapter {
   async start(onInbound: (envelope: BridgeEnvelope) => string): Promise<void> {
     this.onInbound = onInbound;
 
-    // Seed lastMessageId so we don't replay history on boot
-    const recent = await this.fetchMessages(1);
-    if (recent.length > 0) {
-      this.lastMessageId = recent[0].id;
-    }
+    // Seed: set cursor to 30 seconds ago so we catch messages sent during bridge startup
+    // without replaying full history. Uses Discord snowflake format.
+    const lookbackMs = 30_000;
+    const epoch = BigInt(Date.now() - lookbackMs - 1420070400000) * BigInt(2 ** 22);
+    this.lastMessageId = epoch.toString();
 
     this.pollTimer = setInterval(() => { void this.poll(); }, this.pollIntervalMs);
     console.log(`[discord-bridge] Listening on channel ${this.channelId}`);

--- a/packages/cli/test/discord-adapter.test.ts
+++ b/packages/cli/test/discord-adapter.test.ts
@@ -10,17 +10,16 @@ describe("DiscordAdapter", () => {
   });
 
   beforeEach(() => {
+    let pollCount = 0;
     fetchMock = mock(async (url: string, opts?: RequestInit) => {
       const u = String(url);
-      // Seed call (limit=1, no after)
-      if (u.includes("limit=1") && !u.includes("after=")) {
-        return { ok: true, json: async () => [{ id: "1000", author: { bot: false, id: "u1", username: "Alice" }, content: "hi", timestamp: "2026-01-01T00:00:00Z", guild_id: "g1" }] };
+      // Poll call (after=<snowflake>) — first poll returns new message, rest empty
+      if (u.includes("after=")) {
+        pollCount++;
+        if (pollCount === 1) {
+          return { ok: true, json: async () => [{ id: "1001", author: { bot: false, id: "u2", username: "Bob" }, content: "hello", timestamp: "2026-01-01T00:01:00Z", guild_id: "g1", mentions: [] }] };
+        }
       }
-      // Poll call (after=1000) — one new message
-      if (u.includes("after=1000")) {
-        return { ok: true, json: async () => [{ id: "1001", author: { bot: false, id: "u2", username: "Bob" }, content: "hello", timestamp: "2026-01-01T00:01:00Z", guild_id: "g1" }] };
-      }
-      // Subsequent polls — empty
       return { ok: true, json: async () => [] };
     });
     globalThis.fetch = fetchMock as any;


### PR DESCRIPTION
The bridge startup was permanently dropping messages sent just before the bridge started. On boot, `start()` fetched the latest message and used its ID as the cursor — anything sent before that became invisible.

**Fix:** Use `now - 30s` as a synthetic snowflake cursor on boot. Bridge picks up any messages from the last 30 seconds without replaying full history.

This was why Ember never saw Nathan's morning ping both times — the bridge always restarted right after the message, seeding past it.

565/565 tests.