### PR TITLE
fix: default --sandbox to ON for tps agent start (ops-35)

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -479,7 +479,7 @@ export async function runAgent(args: AgentArgs): Promise<void> {
       }
 
       if (args.action === "start") {
-        const sandbox = (args as any).sandbox ?? false;
+        const sandbox = (args as any).sandbox ?? true; // default ON — nono is the required isolation layer
         const sandboxed = (args as any).sandboxed ?? false;
         const nonoAvailable = findNono();
 


### PR DESCRIPTION
nono is the required isolation layer for every agent process — the `tps-agent-run.toml` profile was already written for this. We just forgot to flip the default when wiring up the Codex runtime.

**Before:** `--sandbox` was opt-in (off by default)
**After:** sandbox is always on; nono wraps every `tps agent start`

Behavior:
- nono installed → re-exec under `tps-agent-run` profile (localhost-only network, restricted filesystem)
- nono missing + `TPS_NONO_STRICT=1` → exit non-zero
- nono missing → warn + start unprotected (development fallback)

To opt out during dev: `tps agent start --no-sandbox`

Completes the original ops-35 design. Ember was always supposed to be the first real test of nono isolation. 565/565 tests.