### PR TITLE
fix: git pull --rebase before each Codex task (ops-80)

### DIFF
--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -168,6 +168,7 @@ async function runCodex(
   config: CodexRuntimeConfig,
   taskTimeoutMs: number,
 ): Promise<string> {
+  await syncWorkspaceBeforeTask(config);
   const systemPrompt = await buildSystemPrompt(message, config);
   const sandboxMode = config.sandboxMode ?? "workspace-write";
 
@@ -255,8 +256,46 @@ export interface AutoCommitDeps {
   tpsCommand?: string;
 }
 
+export interface WorkspaceSyncDeps {
+  spawnSyncImpl?: typeof spawnSync;
+  warn?: (message?: any, ...optionalParams: any[]) => void;
+}
+
 interface AutoCommitFlair {
   publishEvent(event: { kind: string; summary: string; detail?: string; refId?: string }): Promise<void>;
+}
+
+function resolveDefaultBranch(repo: string, runSync: typeof spawnSync): string {
+  const headRef = runSync("git", ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], {
+    cwd: repo,
+    encoding: "utf-8",
+  });
+  if ((headRef.status ?? 1) === 0) {
+    const ref = typeof headRef.stdout === "string" ? headRef.stdout.trim() : "";
+    const branch = ref.replace(/^origin\//, "");
+    if (branch) return branch;
+  }
+  return "main";
+}
+
+export async function syncWorkspaceBeforeTask(
+  config: CodexRuntimeConfig,
+  deps: WorkspaceSyncDeps = {},
+): Promise<void> {
+  const runSync = deps.spawnSyncImpl ?? spawnSync;
+  const warn = deps.warn ?? console.warn;
+  const branch = resolveDefaultBranch(config.workspace, runSync);
+  const result = runSync("git", ["pull", "--rebase", "origin", branch], {
+    cwd: config.workspace,
+    encoding: "utf-8",
+  });
+
+  if ((result.status ?? 1) === 0) return;
+
+  const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+  const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
+  const detail = stderr || stdout || `exit ${result.status ?? "unknown"}`;
+  warn(`[${config.agentId}] Workspace sync failed before task (non-fatal): git pull --rebase origin ${branch}: ${detail}`);
 }
 
 export async function runAutoCommit(

--- a/packages/cli/test/auto-commit.test.ts
+++ b/packages/cli/test/auto-commit.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, mock, test } from "bun:test";
-import { runAutoCommit, type CodexRuntimeConfig } from "../src/utils/codex-runtime.ts";
+import {
+  runAutoCommit,
+  syncWorkspaceBeforeTask,
+  type CodexRuntimeConfig,
+} from "../src/utils/codex-runtime.ts";
 
 const config: CodexRuntimeConfig = {
   agentId: "ember",
@@ -94,5 +98,69 @@ describe("runAutoCommit", () => {
       detail: "gh-as pr create failed",
       refId: "task-456",
     });
+  });
+});
+
+describe("syncWorkspaceBeforeTask", () => {
+  test("pulls with the configured remote default branch when origin HEAD is available", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const spawnSyncImpl = mock((cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      if (cmd === "git" && args.join(" ") === "symbolic-ref --quiet --short refs/remotes/origin/HEAD") {
+        return { status: 0, stdout: "origin/trunk\n", stderr: "" };
+      }
+      if (cmd === "git" && args.join(" ") === "pull --rebase origin trunk") {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+    });
+
+    await syncWorkspaceBeforeTask(config, { spawnSyncImpl });
+
+    expect(calls).toEqual([
+      { cmd: "git", args: ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"] },
+      { cmd: "git", args: ["pull", "--rebase", "origin", "trunk"] },
+    ]);
+  });
+
+  test("falls back to main when origin HEAD is not configured", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const spawnSyncImpl = mock((cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      if (cmd === "git" && args.join(" ") === "symbolic-ref --quiet --short refs/remotes/origin/HEAD") {
+        return { status: 1, stdout: "", stderr: "" };
+      }
+      if (cmd === "git" && args.join(" ") === "pull --rebase origin main") {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+    });
+
+    await syncWorkspaceBeforeTask(config, { spawnSyncImpl });
+
+    expect(calls).toEqual([
+      { cmd: "git", args: ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"] },
+      { cmd: "git", args: ["pull", "--rebase", "origin", "main"] },
+    ]);
+  });
+
+  test("warns and continues when rebase fails", async () => {
+    const warn = mock(() => {});
+    const spawnSyncImpl = mock((cmd: string, args: string[]) => {
+      if (cmd === "git" && args.join(" ") === "symbolic-ref --quiet --short refs/remotes/origin/HEAD") {
+        return { status: 0, stdout: "origin/main\n", stderr: "" };
+      }
+      if (cmd === "git" && args.join(" ") === "pull --rebase origin main") {
+        return { status: 1, stdout: "", stderr: "cannot rebase: unstaged changes" };
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+    });
+
+    await syncWorkspaceBeforeTask(config, { spawnSyncImpl, warn });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "[ember] Workspace sync failed before task (non-fatal): git pull --rebase origin main: cannot rebase: unstaged changes",
+    );
   });
 });


### PR DESCRIPTION
Syncs the agent workspace with origin/main before each task to avoid stale-base PRs.

- Adds `syncWorkspaceBeforeTask()` — runs `git pull --rebase origin <default-branch>` in the workspace
- Resolves default branch via `git symbolic-ref` with `main` fallback
- Non-fatal: logs a warning on rebase failure, task still runs
- Adds `WorkspaceSyncDeps` interface for DI in tests
- Full test coverage in `auto-commit.test.ts`

Fixes ops-80.