### PR TITLE
fix: add git worktree metadata dir to Codex extraDirs (ops-87)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -424,6 +424,7 @@ async function main() {
                   join(homedir(), "ops", "tps"),
                   join(homedir(), "ops", "flair"),
                   ...((worktreeGitDir) => worktreeGitDir ? [worktreeGitDir] : [])(resolveWorktreeGitDir(agentWorkspace)),
+                  ...(agentCfg.codex?.extraDirs ?? []),
                 ],
                 taskTimeoutMs: agentCfg.taskTimeoutMs,
                 flairUrl: agentCfg.flair?.url ?? process.env.FLAIR_URL,


### PR DESCRIPTION
Fixes Ember's commit blocker — Codex sandbox was rejecting `index.lock` writes because the git worktree metadata lives outside the workspace dir.

**Root cause:**
- Ember's workspace `~/ops/tps-ember` is a git worktree
- Worktree metadata (index, HEAD, logs) lives at `~/ops/tps/.git/worktrees/tps-ember/`
- Codex `workspace-write` sandbox restricts writes to the workspace dir only
- `git commit` fails when trying to write `index.lock` at the metadata path

**Fix:**
`resolveWorktreeGitDir(workspace)` reads `workspace/.git`:
- If it's a file (worktree): contains `gitdir: /path/to/.git/worktrees/<name>` — parse and return the path
- If it throws (regular repo, .git is a dir): return null

The resolved path is added to Codex's `extraDirs` so sandbox allows writes there.

**Tested:**
- `resolveWorktreeGitDir('~/ops/tps-ember')` → `/Users/squeued/ops/tps/.git/worktrees/tps-ember` ✓
- Regular repos return null (no extra dir added) ✓
- 565/565 tests pass

Fixes ops-87. Stacks on #156 (TPS_AGENT_ID env fix).