### PR TITLE
feat: auto re-request review on force-push dismissal (ops-81)

### DIFF
--- a/packages/cli/src/utils/github-webhook.ts
+++ b/packages/cli/src/utils/github-webhook.ts
@@ -1,8 +1,23 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { FlairClient, defaultFlairKeyPath } from "./flair-client.js";
 import { queueOutboxMessage } from "./outbox.js";
+import { reRequestReviewer, type ReviewRequestDeps } from "./pr-review-trigger.js";
 import snooplogg from "snooplogg";
 const { log: slog, warn: swarn, error: serror } = snooplogg("tps:github");
+
+type ReviewRerequestedPublisher = (event: {
+  summary: string;
+  detail: string;
+  refId: string;
+  targetIds: string[];
+}) => Promise<void>;
+
+export interface GithubWebhookDeps {
+  queueOutboxMessageImpl?: typeof queueOutboxMessage;
+  reviewRequestDeps?: ReviewRequestDeps;
+  publishReviewRerequestedEvent?: ReviewRerequestedPublisher;
+}
 
 
 function webhookSecret(): string {
@@ -13,6 +28,27 @@ function webhookTarget(): string {
   const target = process.env.GITHUB_WEBHOOK_TARGET;
   if (!target) throw new Error("GITHUB_WEBHOOK_TARGET env var required");
   return target;
+}
+
+function webhookAgentId(): string {
+  return process.env.GITHUB_WEBHOOK_AGENT_ID ?? "ember";
+}
+
+function defaultReviewEventPublisher(agentId: string): ReviewRerequestedPublisher {
+  return async (event) => {
+    const flair = new FlairClient({
+      baseUrl: process.env.FLAIR_URL,
+      agentId,
+      keyPath: defaultFlairKeyPath(agentId),
+    });
+    await flair.publishEvent({
+      kind: "review.re-requested",
+      summary: event.summary,
+      detail: event.detail,
+      refId: event.refId,
+      targetIds: event.targetIds,
+    });
+  };
 }
 
 function validateSignature(body: Buffer, sigHeader: string | undefined): boolean {
@@ -79,7 +115,48 @@ function formatEvent(event: string, payload: Record<string, unknown>): string {
   }
 }
 
-export async function handleGithubWebhook(req: IncomingMessage, res: ServerResponse): Promise<void> {
+export async function processGithubWebhookEvent(
+  event: string,
+  payload: Record<string, unknown>,
+  deps: GithubWebhookDeps = {},
+): Promise<void> {
+  if (event !== "pull_request_review" || payload.action !== "dismissed") return;
+  const review = payload.review as Record<string, unknown> | undefined;
+  const reviewer = (review?.user as Record<string, unknown> | undefined)?.login;
+  const pr = payload.pull_request as Record<string, unknown> | undefined;
+  const prNumber = typeof pr?.number === "number" ? pr.number : null;
+  const prUrl = typeof pr?.html_url === "string" ? pr.html_url : "";
+  const repo = (payload.repository as Record<string, unknown> | undefined)?.full_name;
+
+  if (typeof reviewer !== "string" || !reviewer || !prNumber || typeof repo !== "string" || !repo) {
+    swarn("[webhook] pull_request_review dismissed missing reviewer, PR number, or repo");
+    return;
+  }
+
+  const agentId = webhookAgentId();
+  const reRequested = reRequestReviewer(prNumber, reviewer, { agentId, repo }, deps.reviewRequestDeps);
+  if (!reRequested) return;
+
+  const publishEvent = deps.publishReviewRerequestedEvent ?? defaultReviewEventPublisher(agentId);
+  const refId = `${repo}#${prNumber}`;
+  const detail = prUrl || `https://github.com/${repo}/pull/${prNumber}`;
+  try {
+    await publishEvent({
+      summary: `Re-requested review from ${reviewer} on PR #${prNumber}`,
+      detail,
+      refId,
+      targetIds: [reviewer],
+    });
+  } catch (error) {
+    swarn(`[webhook] Failed to publish review.re-requested for PR #${prNumber}: ${(error as Error).message}`);
+  }
+}
+
+export async function handleGithubWebhook(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: GithubWebhookDeps = {},
+): Promise<void> {
   if (!webhookSecret()) {
     swarn("[webhook] GITHUB_WEBHOOK_SECRET not set — all webhook requests will be rejected");
     res.statusCode = 503;
@@ -111,7 +188,9 @@ export async function handleGithubWebhook(req: IncomingMessage, res: ServerRespo
     return;
   }
 
-  queueOutboxMessage(webhookTarget(), formatEvent(event, payload), "github-webhook");
+  const queueMessage = deps.queueOutboxMessageImpl ?? queueOutboxMessage;
+  queueMessage(webhookTarget(), formatEvent(event, payload), "github-webhook");
+  await processGithubWebhookEvent(event, payload, deps);
   res.statusCode = 200;
   res.end("ok");
 }

--- a/packages/cli/src/utils/pr-review-trigger.ts
+++ b/packages/cli/src/utils/pr-review-trigger.ts
@@ -18,6 +18,9 @@ export interface ReviewTriggerConfig {
   agentId: string;       // gh-as identity (e.g. "anvil")
   repo: string;          // owner/repo (e.g. "tpsdev-ai/cli")
 }
+export interface ReviewRequestDeps {
+  spawnSyncImpl?: typeof spawnSync;
+}
 
 /**
  * Extract PR number from a GitHub PR URL.
@@ -35,12 +38,14 @@ function extractPrNumber(detail: string): number | null {
 export function requestReviews(
   prNumber: number,
   config: ReviewTriggerConfig,
+  deps: ReviewRequestDeps = {},
 ): boolean {
   const { reviewers, agentId, repo } = config;
   if (reviewers.length === 0) return true;
+  const runSync = deps.spawnSyncImpl ?? spawnSync;
 
   const body = JSON.stringify({ reviewers });
-  const result = spawnSync(
+  const result = runSync(
     "gh-as",
     [agentId, "api", "--method", "POST", `repos/${repo}/pulls/${prNumber}/requested_reviewers`, "--input", "-"],
     { input: body, encoding: "utf-8" },
@@ -52,6 +57,15 @@ export function requestReviews(
   }
   slog(`[pr-review-trigger] Requested review on PR #${prNumber} from: ${reviewers.join(", ")}`);
   return true;
+}
+
+export function reRequestReviewer(
+  prNumber: number,
+  reviewer: string,
+  config: Omit<ReviewTriggerConfig, "reviewers">,
+  deps: ReviewRequestDeps = {},
+): boolean {
+  return requestReviews(prNumber, { ...config, reviewers: [reviewer] }, deps);
 }
 
 /**

--- a/packages/cli/test/github-webhook.test.ts
+++ b/packages/cli/test/github-webhook.test.ts
@@ -3,16 +3,28 @@ import { createHmac } from "node:crypto";
 import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createServer } from "node:http";
-import { handleGithubWebhook } from "../src/utils/github-webhook.js";
+import { PassThrough } from "node:stream";
+import { handleGithubWebhook, processGithubWebhookEvent } from "../src/utils/github-webhook.js";
 
-async function post(port: number, headers: Record<string, string>, body: string): Promise<{ status: number; text: string }> {
-  const res = await fetch(`http://127.0.0.1:${port}/github/webhook`, {
-    method: "POST",
-    headers,
-    body,
-  });
-  return { status: res.status, text: await res.text() };
+async function post(
+  headers: Record<string, string>,
+  body: string,
+  deps?: Parameters<typeof handleGithubWebhook>[2],
+): Promise<{ status: number; text: string }> {
+  const req = new PassThrough() as PassThrough & { headers: Record<string, string> };
+  req.headers = headers;
+  let text = "";
+  const res = {
+    statusCode: 200,
+    end(chunk?: string) {
+      text = chunk ?? "";
+    },
+  } as { statusCode: number; end: (chunk?: string) => void };
+
+  const pending = handleGithubWebhook(req as any, res as any, deps);
+  req.end(body);
+  await pending;
+  return { status: res.statusCode, text };
 }
 
 describe("handleGithubWebhook", () => {
@@ -27,61 +39,33 @@ describe("handleGithubWebhook", () => {
   afterEach(() => {
     rmSync(root, { recursive: true, force: true });
     delete process.env.HOME;
+    delete process.env.GITHUB_WEBHOOK_AGENT_ID;
     delete process.env.GITHUB_WEBHOOK_TARGET;
     delete process.env.GITHUB_WEBHOOK_SECRET;
   });
 
   test("returns 503 when secret is not set", async () => {
     delete process.env.GITHUB_WEBHOOK_SECRET;
-    const server = createServer((req, res) => {
-      handleGithubWebhook(req, res).catch(() => {
-        res.statusCode = 500;
-        res.end();
-      });
-    });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
-    const port = (server.address() as any).port as number;
-
-    const r = await post(port, {
+    const r = await post({
       "content-type": "application/json",
       "x-github-event": "push",
     }, JSON.stringify({ repository: { full_name: "a/b" } }));
 
     expect(r.status).toBe(503);
-    await new Promise<void>((resolve) => server.close(() => resolve()));
     process.env.GITHUB_WEBHOOK_SECRET = "testsecret";
   });
 
   test("returns 401 on invalid signature", async () => {
-    const server = createServer((req, res) => {
-      handleGithubWebhook(req, res).catch(() => {
-        res.statusCode = 500;
-        res.end();
-      });
-    });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
-    const port = (server.address() as any).port as number;
-
-    const r = await post(port, {
+    const r = await post({
       "content-type": "application/json",
       "x-github-event": "push",
       "x-hub-signature-256": "sha256=bad",
     }, JSON.stringify({ repository: { full_name: "a/b" } }));
 
     expect(r.status).toBe(401);
-    await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 
   test("returns 200 and queues push event", async () => {
-    const server = createServer((req, res) => {
-      handleGithubWebhook(req, res).catch(() => {
-        res.statusCode = 500;
-        res.end();
-      });
-    });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
-    const port = (server.address() as any).port as number;
-
     const payload = JSON.stringify({
       ref: "refs/heads/main",
       after: "abc12345def",
@@ -91,7 +75,7 @@ describe("handleGithubWebhook", () => {
     });
     const sig = `sha256=${createHmac("sha256", "testsecret").update(payload).digest("hex")}`;
 
-    const r = await post(port, {
+    const r = await post({
       "content-type": "application/json",
       "x-github-event": "push",
       "x-hub-signature-256": sig,
@@ -105,7 +89,78 @@ describe("handleGithubWebhook", () => {
     const row = JSON.parse(readFileSync(join(outDir, files[0]!), "utf-8"));
     expect(row.to).toBe("host");
     expect(String(row.body)).toContain("push");
+  });
 
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+  test("processGithubWebhookEvent: re-requests dismissed reviewer and publishes OrgEvent", async () => {
+    const ghCalls: Array<{ cmd: string; args: string[]; input?: string }> = [];
+    const published: Array<{ summary: string; detail: string; refId: string; targetIds: string[] }> = [];
+    process.env.GITHUB_WEBHOOK_AGENT_ID = "ember";
+
+    await processGithubWebhookEvent("pull_request_review", {
+      action: "dismissed",
+      repository: { full_name: "tpsdev-ai/cli" },
+      pull_request: { number: 144, html_url: "https://github.com/tpsdev-ai/cli/pull/144" },
+      review: { user: { login: "tps-kern" } },
+    }, {
+      reviewRequestDeps: {
+        spawnSyncImpl: ((cmd: string, args: string[], opts?: { input?: string }) => {
+          ghCalls.push({ cmd, args, input: opts?.input });
+          return { status: 0, stdout: "", stderr: "" } as any;
+        }) as any,
+      },
+      publishReviewRerequestedEvent: async (event) => {
+        published.push(event);
+      },
+    });
+
+    expect(ghCalls).toHaveLength(1);
+    expect(ghCalls[0]?.cmd).toBe("gh-as");
+    expect(ghCalls[0]?.args).toEqual([
+      "ember",
+      "api",
+      "--method",
+      "POST",
+      "repos/tpsdev-ai/cli/pulls/144/requested_reviewers",
+      "--input",
+      "-",
+    ]);
+    expect(ghCalls[0]?.input).toBe(JSON.stringify({ reviewers: ["tps-kern"] }));
+    expect(published).toEqual([{
+      summary: "Re-requested review from tps-kern on PR #144",
+      detail: "https://github.com/tpsdev-ai/cli/pull/144",
+      refId: "tpsdev-ai/cli#144",
+      targetIds: ["tps-kern"],
+    }]);
+
+    delete process.env.GITHUB_WEBHOOK_AGENT_ID;
+  });
+  test("returns 200 for dismissed review webhook and keeps outbox behavior", async () => {
+    const published: Array<{ summary: string; detail: string; refId: string; targetIds: string[] }> = [];
+    const payload = JSON.stringify({
+      action: "dismissed",
+      repository: { full_name: "tpsdev-ai/cli" },
+      pull_request: { number: 145, title: "Fix review rerequest flow", user: { login: "ember" }, html_url: "https://github.com/tpsdev-ai/cli/pull/145" },
+      review: { user: { login: "tps-sherlock" } },
+    });
+    const sig = `sha256=${createHmac("sha256", "testsecret").update(payload).digest("hex")}`;
+    const r = await post({
+      "content-type": "application/json",
+      "x-github-event": "pull_request_review",
+      "x-hub-signature-256": sig,
+    }, payload, {
+      reviewRequestDeps: {
+        spawnSyncImpl: ((_: string, __: string[], ___?: { input?: string }) => ({ status: 0, stdout: "", stderr: "" })) as any,
+      },
+      publishReviewRerequestedEvent: async (event) => {
+        published.push(event);
+      },
+    });
+    expect(r.status).toBe(200);
+    const outDir = join(root, ".tps", "outbox", "new");
+    const files = readdirSync(outDir).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBe(1);
+    const row = JSON.parse(readFileSync(join(outDir, files[0]!), "utf-8"));
+    expect(String(row.body)).toContain("pull_request_review");
+    expect(published).toHaveLength(1);
   });
 });

--- a/packages/cli/test/pr-review-trigger.test.ts
+++ b/packages/cli/test/pr-review-trigger.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect, afterEach, mock } from "bun:test";
-import { requestReviews, handlePrOpened, type ReviewTriggerConfig } from "../src/utils/pr-review-trigger.js";
+import { describe, test, expect } from "bun:test";
+import { requestReviews, reRequestReviewer, handlePrOpened, type ReviewTriggerConfig } from "../src/utils/pr-review-trigger.js";
 
 const cfg: ReviewTriggerConfig = {
   reviewers: ["tps-kern", "tps-sherlock"],
@@ -9,7 +9,6 @@ const cfg: ReviewTriggerConfig = {
 
 describe("pr-review-trigger", () => {
   test("extractPrNumber: parses GitHub PR URL from event detail", async () => {
-    const calls: string[][] = [];
     // Mock spawnSync by testing handlePrOpened with a known URL
     // We can't easily mock spawnSync but we can test the URL parsing logic
     // by checking what requestReviews does with a bad PR number
@@ -37,5 +36,41 @@ describe("pr-review-trigger", () => {
   test("requestReviews: returns true when reviewers list is empty", () => {
     const result = requestReviews(131, { ...cfg, reviewers: [] });
     expect(result).toBe(true);
+  });
+
+  test("requestReviews: posts reviewer payload through gh-as", () => {
+    const calls: Array<{ cmd: string; args: string[]; input?: string }> = [];
+    const result = requestReviews(131, cfg, {
+      spawnSyncImpl: ((cmd: string, args: string[], opts?: { input?: string }) => {
+        calls.push({ cmd, args, input: opts?.input });
+        return { status: 0, stdout: "", stderr: "" } as any;
+      }) as any,
+    });
+
+    expect(result).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cmd).toBe("gh-as");
+    expect(calls[0]?.args).toEqual([
+      "anvil",
+      "api",
+      "--method",
+      "POST",
+      "repos/tpsdev-ai/cli/pulls/131/requested_reviewers",
+      "--input",
+      "-",
+    ]);
+    expect(calls[0]?.input).toBe(JSON.stringify({ reviewers: ["tps-kern", "tps-sherlock"] }));
+  });
+  test("reRequestReviewer: requests only the dismissed reviewer", () => {
+    const calls: Array<{ input?: string }> = [];
+    const result = reRequestReviewer(77, "reviewer-1", { agentId: "ember", repo: "tpsdev-ai/cli" }, {
+      spawnSyncImpl: ((_: string, __: string[], opts?: { input?: string }) => {
+        calls.push({ input: opts?.input });
+        return { status: 0, stdout: "", stderr: "" } as any;
+      }) as any,
+    });
+
+    expect(result).toBe(true);
+    expect(calls[0]?.input).toBe(JSON.stringify({ reviewers: ["reviewer-1"] }));
   });
 });


### PR DESCRIPTION
Ember implemented. Extends pr-review-trigger to handle review.dismissed events — re-requests review from dismissed reviewer and publishes review.re-requested OrgEvent.

4 files changed, +232 lines. Tests included.