### PR TITLE
fix: propagate push + openPr through autoCommit pipeline (ops-88)

### DIFF
--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -9,7 +9,7 @@ import {
   readFileSync, existsSync, mkdirSync, readdirSync,
   renameSync, writeFileSync, appendFileSync, createWriteStream,
 } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { FlairClient, defaultFlairKeyPath } from "./flair-client.js";
@@ -81,6 +81,14 @@ export interface AutoCommitConfig {
   authorEmail?: string;
   /** Push branch to origin and open PR after commit */
   push?: boolean;
+  /** Open a PR after pushing the branch */
+  openPr?: boolean;
+  /** Repo slug to target when opening a PR, e.g. "org/repo" */
+  prRepo?: string;
+  /** PR title to use when opening a PR */
+  prTitle?: string;
+  /** Path to the GitHub PAT file; basename maps to gh-as agent handle */
+  githubPat?: string;
 }
 
 export interface CodexRuntimeConfig {
@@ -249,6 +257,10 @@ export interface AutoCommitOptions {
   commitMessage: string;
   authorName: string;
   authorEmail: string;
+  push?: boolean;
+  openPr?: boolean;
+  prRepo?: string;
+  ghAgent?: string;
   prTitle?: string;
 }
 
@@ -308,7 +320,18 @@ export async function runAutoCommit(
   const runSync = deps.spawnSyncImpl ?? spawnSync;
   const tpsCmd = deps.tpsCommand ?? "tps";
   const repo = config.workspace;
-  const { taskId, branchName, commitMessage, authorName, authorEmail, prTitle } = options;
+  const {
+    taskId,
+    branchName,
+    commitMessage,
+    authorName,
+    authorEmail,
+    push,
+    openPr,
+    prRepo,
+    ghAgent,
+    prTitle,
+  } = options;
 
   // Ensure we're on a named branch (not detached HEAD) before committing
   const headCheck = runSync("git", ["symbolic-ref", "--quiet", "HEAD"], { cwd: repo, encoding: "utf-8" });
@@ -326,11 +349,43 @@ export async function runAutoCommit(
     "--branch", branchName,
     "--message", commitMessage,
     "--author", authorName, authorEmail,
-    ...(prTitle ? ["--pr-title", prTitle] : []),
+    ...(push ? ["--push"] : []),
+    ...(prTitle && !(openPr && prRepo) ? ["--pr-title", prTitle] : []),
   ];
 
   const result = runSync(tpsCmd, args, { cwd: repo, encoding: "utf-8" });
-  if (result.status === 0) return;
+  if (result.status === 0) {
+    if (push && openPr && prRepo) {
+      const prArgs = [
+        ghAgent ?? authorEmail.split("@")[0] ?? "",
+        "pr",
+        "create",
+        "--repo",
+        prRepo,
+        "--head",
+        branchName,
+        ...(prTitle ? ["--title", prTitle] : []),
+        "--body",
+        commitMessage,
+      ];
+      const prResult = runSync("gh-as", prArgs, { cwd: repo, encoding: "utf-8" });
+      if ((prResult.status ?? 1) === 0) return;
+
+      const prStderr = typeof prResult.stderr === "string" ? prResult.stderr.trim() : "";
+      const prStdout = typeof prResult.stdout === "string" ? prResult.stdout.trim() : "";
+      const prErrMsg = prStderr || prStdout || `exit ${prResult.status ?? "unknown"}`;
+      try {
+        await flair.publishEvent({
+          kind: "blocker",
+          summary: `PR creation failed for ${taskId}`,
+          detail: prErrMsg,
+          refId: taskId,
+        });
+      } catch { /* non-fatal */ }
+      throw new Error(`gh-as pr create failed: ${prErrMsg}`);
+    }
+    return;
+  }
 
   const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
   const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
@@ -365,13 +420,27 @@ async function _runAutoCommitLegacy(
   const authorEmail = cfg.authorEmail ?? `${agentId}@tps.dev`;
   const tpsBin = join(homedir(), ".tps", "bin", "tps");
   const tpsCommand = existsSync(tpsBin) ? tpsBin : undefined;
+  const ghAgent = cfg.githubPat
+    ? basename(cfg.githubPat).replace(/-github-pat(?:\.[^.]+)?$/, "").replace(/\.[^.]+$/, "")
+    : undefined;
 
   console.log(`[${agentId}] Auto-commit: ${safeBranch} in ${workspace}`);
   try {
     await runAutoCommit(
-      { agentId, workspace, mailDir: "" },
+      { agentId, workspace: cfg.repo ?? workspace, mailDir: "" },
       flair,
-      { taskId, branchName: safeBranch, commitMessage: `task complete: ${taskId}`, authorName, authorEmail },
+      {
+        taskId,
+        branchName: safeBranch,
+        commitMessage: `task complete: ${taskId}`,
+        authorName,
+        authorEmail,
+        push: cfg.push,
+        openPr: cfg.openPr,
+        prRepo: cfg.prRepo,
+        ghAgent,
+        prTitle: cfg.prTitle,
+      },
       { tpsCommand },
     );
     console.log(`[${agentId}] Auto-commit succeeded: ${safeBranch}`);

--- a/packages/cli/test/auto-commit.test.ts
+++ b/packages/cli/test/auto-commit.test.ts
@@ -37,6 +37,7 @@ describe("runAutoCommit", () => {
         commitMessage: "feat: ship task 123",
         authorName: "ember",
         authorEmail: "ember@tps.dev",
+        push: true,
         prTitle: "feat: ship task 123",
       },
       { spawnSyncImpl },
@@ -59,6 +60,7 @@ describe("runAutoCommit", () => {
           "--author",
           "ember",
           "ember@tps.dev",
+          "--push",
           "--pr-title",
           "feat: ship task 123",
         ],
@@ -66,14 +68,100 @@ describe("runAutoCommit", () => {
     ]);
   });
 
-  test("publishes a blocker OrgEvent when PR creation fails with exit code 2", async () => {
+  test("opens a PR via gh-as when push, openPr, and prRepo are configured", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const spawnSyncImpl = mock((cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      if (cmd === "git" && args.join(" ") === "symbolic-ref --quiet HEAD") {
+        return { status: 0, stdout: "refs/heads/feat/task-456\n", stderr: "" };
+      }
+      if (cmd === "tps") {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (cmd === "gh-as") {
+        return { status: 0, stdout: "https://github.com/tpsdev-ai/cli/pull/123\n", stderr: "" };
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+    });
+
+    await runAutoCommit(
+      config,
+      { publishEvent: mock(async () => {}) },
+      {
+        taskId: "task-456",
+        branchName: "feat/task-456",
+        commitMessage: "feat: ship task 456",
+        authorName: "Ember",
+        authorEmail: "ember@tps.dev",
+        push: true,
+        openPr: true,
+        prRepo: "tpsdev-ai/cli",
+        ghAgent: "ember",
+        prTitle: "feat: ship task 456",
+      },
+      { spawnSyncImpl },
+    );
+
+    expect(calls).toEqual([
+      { cmd: "git", args: ["symbolic-ref", "--quiet", "HEAD"] },
+      {
+        cmd: "tps",
+        args: [
+          "agent",
+          "commit",
+          "--repo",
+          "/tmp/repo",
+          "--branch",
+          "feat/task-456",
+          "--message",
+          "feat: ship task 456",
+          "--author",
+          "Ember",
+          "ember@tps.dev",
+          "--push",
+        ],
+      },
+      {
+        cmd: "gh-as",
+        args: [
+          "ember",
+          "pr",
+          "create",
+          "--repo",
+          "tpsdev-ai/cli",
+          "--head",
+          "feat/task-456",
+          "--title",
+          "feat: ship task 456",
+          "--body",
+          "feat: ship task 456",
+        ],
+      },
+    ]);
+  });
+
+  test("publishes a blocker OrgEvent when runtime PR creation fails", async () => {
     const publishEvent = mock(async () => {});
     const spawnSyncImpl = mock((cmd: string, args: string[]) => {
       if (cmd === "git" && args.join(" ") === "symbolic-ref --quiet HEAD") {
         return { status: 0, stdout: "refs/heads/feat/task-456\n", stderr: "" };
       }
       if (cmd === "tps") {
-        return { status: 2, stdout: "", stderr: "gh-as pr create failed" };
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (cmd === "gh-as") {
+        expect(args).toEqual([
+          "ember",
+          "pr",
+          "create",
+          "--repo",
+          "tpsdev-ai/cli",
+          "--head",
+          "feat/task-456",
+          "--body",
+          "feat: ship task 456",
+        ]);
+        return { status: 1, stdout: "", stderr: "gh-as pr create failed" };
       }
       throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
     });
@@ -87,9 +175,13 @@ describe("runAutoCommit", () => {
         commitMessage: "feat: ship task 456",
         authorName: "ember",
         authorEmail: "ember@tps.dev",
+        push: true,
+        openPr: true,
+        prRepo: "tpsdev-ai/cli",
+        ghAgent: "ember",
       },
       { spawnSyncImpl },
-    )).rejects.toThrow("tps agent commit failed: gh-as pr create failed");
+    )).rejects.toThrow("gh-as pr create failed: gh-as pr create failed");
 
     expect(publishEvent).toHaveBeenCalledTimes(1);
     expect(publishEvent).toHaveBeenCalledWith({


### PR DESCRIPTION
Closes the auto-commit loop: Ember commits → pushes branch → opens PR autonomously.

**Root cause:** `_runAutoCommitLegacy` called `runAutoCommit` without forwarding `push`, `openPr`, or `prRepo` from agent.yaml's `autoCommit` config. The commit happened but the work stayed stranded in the worktree.

**Fix:**
- `AutoCommitOptions`: add `push`, `openPr`, `prRepo` fields
- `runAutoCommit`: pass `--push` to `tps agent commit` when `push=true`; run `gh pr create` when `openPr=true` + `prRepo` set
- `_runAutoCommitLegacy`: forward all three from `AutoCommitConfig`

**After this lands:** Ember closes the full loop solo — task → code → commit → push → PR — without Anvil or Flint manually pushing.

Implemented by Ember. 576/576 tests.