### PR TITLE
test: ops-88 smoke test — add comment to task-result-mail.ts

### DIFF
--- a/packages/cli/src/utils/task-result-mail.ts
+++ b/packages/cli/src/utils/task-result-mail.ts
@@ -1,3 +1,4 @@
+// ops-88 smoke test passed
 export function formatTaskCompleteMailBody(summary: string, prefix = "Task complete"): string {
   const trimmedSummary = summary.trimStart();
   const prefixPattern = new RegExp(`^${prefix}:?(?:\\r?\\n\\s*|\\s+)`, "i");


### PR DESCRIPTION
Smoke test for the autonomous loop. Close without merging — this verifies Ember committed and the pipeline ran. Auto-push didn't fire because the installed tps binary was stale (pre-ops-88). Fixed by installing dev wrapper at ~/.tps/bin/tps.