### PR TITLE
fix: remove git commit instruction from agent system prompt (ops-88 followup)

### DIFF
--- a/packages/cli/src/utils/agent-lifecycle.ts
+++ b/packages/cli/src/utils/agent-lifecycle.ts
@@ -131,8 +131,7 @@ System prompt sourced from: ${identitySource === "flair" ? "Flair (live)" : "⚠
 When you finish a task, use Bash to send mail:
   cd ${workspace} && tps mail send ${supervisor} "done: <summary>"
 
-Always commit your work before mailing ${supervisor}:
-  git add -A && git commit --author="${agentId} <${agentId}@tps.dev>" -m "feat: ..."
+Do NOT run git add, git commit, or git push — the TPS runtime commits and opens a PR automatically after you reply. Just edit the files and send mail when done."
 `.trim());
 
   return { systemPrompt: parts.join("\n\n"), identitySource };


### PR DESCRIPTION
The system prompt in `agent-lifecycle.ts` told agents to run `git add && git commit` before mailing. This caused Ember to attempt commits inside the Codex sandbox, which can't write to `.git/objects`, corrupting the worktree.

**Fix:** Replace the commit instruction with an explicit note that the TPS runtime handles committing and PR creation automatically after the agent replies. Agents should only edit files and send mail.

480/480 tests pass.