### PR TITLE
fix: tps agent commit skips re-commit when agent already committed (ops-88 followup)

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -605,10 +605,19 @@ async function commitAgentChanges(args: AgentArgs): Promise<void> {
   }
 
   const diff = runGit(["diff", "--cached", "--quiet"], repoPath);
-  if (diff.status === 0) failWith("No changes staged for commit.");
-
-  runGitOrFail(["commit", "--author", `${authorName} <${authorEmail}>`, "-m", commitMessage!], repoPath, "git commit");
-  console.log(`Committed changes in ${repoPath} on branch ${branchName}.`);
+  if (diff.status === 0) {
+    // Nothing staged — check if HEAD is already ahead of origin (agent self-committed)
+    const ahead = runGit(["rev-list", "--count", `origin/${branchName!}..HEAD`], repoPath);
+    const aheadCount = parseInt((ahead.stdout ?? "").trim(), 10);
+    if (Number.isNaN(aheadCount) || aheadCount === 0) {
+      failWith("No changes staged for commit.");
+    }
+    // Already committed — skip to push
+    console.log(`Changes already committed on ${branchName}. Skipping commit step.`);
+  } else {
+    runGitOrFail(["commit", "--author", `${authorName} <${authorEmail}>`, "-m", commitMessage!], repoPath, "git commit");
+    console.log(`Committed changes in ${repoPath} on branch ${branchName}.`);
+  }
 
   if (!doPush) return;
 


### PR DESCRIPTION
When an agent self-commits inside Codex before `runAutoCommit` fires, `tps agent commit` found nothing staged and failed silently. Root cause: `git` is in nono's allowlist and the workspace is writable, so Ember can commit directly.

**Fix:** After staging finds nothing, check if HEAD is ahead of `origin/<branch>`. If yes — agent already committed — skip the commit step and continue to push + PR.

This is the last blocker in the autonomous loop. After this merges, smoke test 5 should produce a PR with zero manual intervention.

480/480 tests.