### PR TITLE
fix: block git commit/push inside Codex sandbox via PATH wrapper

### DIFF
--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -197,7 +197,9 @@ async function runCodex(
   const logStream = createWriteStream(logPath, { flags: "a" });
 
   return new Promise((resolve, reject) => {
-    const proc = spawn("codex", args, { cwd: config.workspace, env: process.env });
+    const codexToolsDir = join(homedir(), ".tps", "bin", "codex-tools");
+    const codexEnv = { ...process.env, PATH: `${codexToolsDir}:${process.env.PATH ?? ""}` };
+    const proc = spawn("codex", args, { cwd: config.workspace, env: codexEnv });
     proc.stdin.write(prompt);
     proc.stdin.end();
 


### PR DESCRIPTION
Codex subprocesses could run `git commit` directly, racing with the runtime's `runAutoCommit` and leaving nothing to stage when the runtime ran.

**Root cause:** `git` is in nono's exec allowlist (needed by the runtime), and the Codex `workspace-write` sandbox only restricts file write paths, not which commands can run.

**Fix:** Prepend `~/.tps/bin/codex-tools` to Codex's `PATH`. A `git` wrapper there passes all git commands through EXCEPT `commit` and `push`, which exit 1 with an explanatory message directing to the TPS runtime.

**Effect:** Single clean commit path — Ember writes code → runtime commits + pushes + opens PR. No races, no workarounds.

The wrapper lives at `~/.tps/bin/codex-tools/git` and must be present on the host (will add `tps init` provisioning in a follow-up).

480/480 tests.