### PR TITLE
fix: use /usr/bin/git in tps agent commit to bypass Codex PATH wrapper

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -557,7 +557,10 @@ function isWithinDir(root: string, target: string): boolean {
 
 function runGit(args: string[], cwd: string): { ok: boolean; stdout: string; stderr: string; status: number } {
   const { spawnSync } = require("node:child_process");
-  const r = spawnSync("git", args, { cwd, encoding: "utf-8" });
+  // Use /usr/bin/git directly to bypass the codex-tools git wrapper
+  // (the wrapper blocks commit/push for sandboxed agents, but tps agent commit is the runtime)
+  const gitBin = process.env.TPS_GIT_BIN ?? "/usr/bin/git";
+  const r = spawnSync(gitBin, args, { cwd, encoding: "utf-8" });
   return { ok: r.status === 0, stdout: (r.stdout ?? "").trim(), stderr: (r.stderr ?? "").trim(), status: r.status ?? 1 };
 }
 


### PR DESCRIPTION
The git wrapper at `~/.tps/bin/codex-tools/git` (injected into Codex's PATH via `codexEnv`) blocks `git commit`/`git push` for agents. But `tps agent commit` was also calling bare `git`, hitting the same wrapper and failing.

**Fix:** Use absolute path `/usr/bin/git` in `runGit()` so the runtime's own commit bypasses the PATH wrapper. Codex subprocesses still see the blocked wrapper.

480/480 tests.