### PR TITLE
fix: always pass --title to gh pr create in autoCommit (ops-88 followup)

### DIFF
--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -375,7 +375,7 @@ export async function runAutoCommit(
         prRepo,
         "--head",
         branchName,
-        ...(prTitle ? ["--title", prTitle] : []),
+        "--title", prTitle ?? `task: ${taskId}`,
         "--body",
         commitMessage,
       ];

--- a/packages/cli/test/auto-commit.test.ts
+++ b/packages/cli/test/auto-commit.test.ts
@@ -158,6 +158,8 @@ describe("runAutoCommit", () => {
           "tpsdev-ai/cli",
           "--head",
           "feat/task-456",
+          "--title",
+          "feat: ship task 456",
           "--body",
           "feat: ship task 456",
         ]);
@@ -179,6 +181,7 @@ describe("runAutoCommit", () => {
         openPr: true,
         prRepo: "tpsdev-ai/cli",
         ghAgent: "ember",
+        prTitle: "feat: ship task 456",
       },
       { spawnSyncImpl },
     )).rejects.toThrow("gh-as pr create failed: gh-as pr create failed");


### PR DESCRIPTION
`gh pr create` requires `--title` when non-interactive. When `prTitle` is not configured in agent.yaml, PR creation failed with 'must provide --title and --body'.

**Fix:** Use `prTitle ?? `task: ${taskId}`` as fallback title.

480/480 tests.