### PR TITLE
fix: always checkout default branch before rebase in syncWorkspaceBeforeTask

### DIFF
--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -321,10 +321,12 @@ export async function syncWorkspaceBeforeTask(
   const warn = deps.warn ?? console.warn;
   const branch = resolveDefaultBranch(config.workspace, runSync);
 
-  // Ensure we're on a named branch (worktrees start detached via git worktree add --detach)
-  const headCheck = runSync(GIT_BIN, ["symbolic-ref", "--quiet", "HEAD"], { cwd: config.workspace, encoding: "utf-8" });
-  if ((headCheck.status ?? 1) !== 0) {
-    runSync(GIT_BIN, ["checkout", branch], { cwd: config.workspace, encoding: "utf-8" });
+  // Always checkout default branch before rebase — task branches or detached HEAD both need this.
+  // Without explicit checkout, old task branches with conflict markers survive the rebase.
+  const checkoutResult = runSync(GIT_BIN, ["checkout", branch], { cwd: config.workspace, encoding: "utf-8" });
+  if ((checkoutResult.status ?? 1) !== 0) {
+    const stderr = typeof checkoutResult.stderr === "string" ? checkoutResult.stderr.trim() : "";
+    warn(`[${config.agentId}] git checkout ${branch} failed (non-fatal): ${stderr}`);
   }
   const result = runSync(GIT_BIN, ["pull", "--rebase", "origin", branch], {
     cwd: config.workspace,

--- a/packages/cli/test/auto-commit.test.ts
+++ b/packages/cli/test/auto-commit.test.ts
@@ -251,8 +251,8 @@ describe("syncWorkspaceBeforeTask", () => {
       if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet --short refs/remotes/origin/HEAD") {
         return { status: 0, stdout: "origin/trunk\n", stderr: "" };
       }
-      if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet HEAD") {
-        return { status: 0, stdout: "refs/heads/trunk\n", stderr: "" };
+      if (cmd === "/usr/bin/git" && args.join(" ") === "checkout trunk") {
+        return { status: 0, stdout: "", stderr: "" };
       }
       if (cmd === "/usr/bin/git" && args.join(" ") === "pull --rebase origin trunk") {
         return { status: 0, stdout: "", stderr: "" };
@@ -264,7 +264,7 @@ describe("syncWorkspaceBeforeTask", () => {
 
     expect(calls).toEqual([
       { cmd: "/usr/bin/git", args: ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"] },
-      { cmd: "/usr/bin/git", args: ["symbolic-ref", "--quiet", "HEAD"] },
+      { cmd: "/usr/bin/git", args: ["checkout", "trunk"] },
       { cmd: "/usr/bin/git", args: ["pull", "--rebase", "origin", "trunk"] },
     ]);
   });
@@ -276,8 +276,8 @@ describe("syncWorkspaceBeforeTask", () => {
       if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet --short refs/remotes/origin/HEAD") {
         return { status: 1, stdout: "", stderr: "" };
       }
-      if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet HEAD") {
-        return { status: 0, stdout: "refs/heads/main\n", stderr: "" };
+      if (cmd === "/usr/bin/git" && args.join(" ") === "checkout main") {
+        return { status: 0, stdout: "", stderr: "" };
       }
       if (cmd === "/usr/bin/git" && args.join(" ") === "pull --rebase origin main") {
         return { status: 0, stdout: "", stderr: "" };
@@ -289,7 +289,7 @@ describe("syncWorkspaceBeforeTask", () => {
 
     expect(calls).toEqual([
       { cmd: "/usr/bin/git", args: ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"] },
-      { cmd: "/usr/bin/git", args: ["symbolic-ref", "--quiet", "HEAD"] },
+      { cmd: "/usr/bin/git", args: ["checkout", "main"] },
       { cmd: "/usr/bin/git", args: ["pull", "--rebase", "origin", "main"] },
     ]);
   });
@@ -300,8 +300,8 @@ describe("syncWorkspaceBeforeTask", () => {
       if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet --short refs/remotes/origin/HEAD") {
         return { status: 0, stdout: "origin/main\n", stderr: "" };
       }
-      if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet HEAD") {
-        return { status: 0, stdout: "refs/heads/main\n", stderr: "" };
+      if (cmd === "/usr/bin/git" && args.join(" ") === "checkout main") {
+        return { status: 0, stdout: "", stderr: "" };
       }
       if (cmd === "/usr/bin/git" && args.join(" ") === "pull --rebase origin main") {
         return { status: 1, stdout: "", stderr: "cannot rebase: unstaged changes" };


### PR DESCRIPTION
Root cause of Ember PRs with conflict markers (#184, #186): `syncWorkspaceBeforeTask` only handled detached HEAD, not named task branches. Old task branches with conflict markers survived the `git pull --rebase`.

Fix: unconditionally run `git checkout <defaultBranch>` before the rebase. Non-fatal on failure.

490/490 tests.