### PR TITLE
fix: smarter Gemini reply extraction — skip narration, 1 para for short outputs

### DIFF
--- a/packages/cli/src/utils/gemini-runtime.ts
+++ b/packages/cli/src/utils/gemini-runtime.ts
@@ -113,7 +113,10 @@ async function buildPrompt(message: MailMessage, config: GeminiConfig): Promise<
 
 /**
  * Extract the final answer from Gemini output.
- * Strips YOLO banners, preamble, ANSI codes, then returns last 3 paragraphs.
+ * Strips YOLO banners, preamble, ANSI codes, then returns the last paragraph
+ * for short outputs (≤5 paragraphs) or last 3 for longer ones.
+ * Narration paragraphs (starting with "I'll", "I've", "Okay", etc.) are
+ * skipped when walking backward to find the final substantive reply.
  */
 export function extractFinalAnswer(raw: string): string {
   const STRIP_PREFIXES = [
@@ -122,6 +125,7 @@ export function extractFinalAnswer(raw: string): string {
     "All tool calls will be automatically approved.",
     "missing pgrep output",
   ];
+  const NARRATION_RE = /^(I['\u2019]ll|I['\u2019]ve|Okay[,.]|Now I|Let me|I will|I need|I should|I am going|I can|I have to|First,|Next,|Then,|Now,|Finally,)/i;
   // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape stripping requires ESC
   const stripped = raw.replace(/\u001b\[[0-9;]*m/g, "");
   const lines = stripped.split("\n").filter(
@@ -130,7 +134,12 @@ export function extractFinalAnswer(raw: string): string {
   const cleaned = lines.join("\n").trim();
   const paragraphs = cleaned.split(/\n\n+/).map((p) => p.trim()).filter(Boolean);
   if (paragraphs.length === 0) return cleaned;
-  return paragraphs.slice(-3).join("\n\n");
+  // Walk backward to find last non-narration paragraph
+  let end = paragraphs.length - 1;
+  while (end > 0 && NARRATION_RE.test(paragraphs[end])) end--;
+  // For short outputs take just that paragraph; longer outputs take up to 3
+  const count = paragraphs.length > 5 ? 3 : 1;
+  return paragraphs.slice(Math.max(0, end - count + 1), end + 1).join("\n\n");
 }
 
 async function runGemini(message: MailMessage, config: GeminiConfig, taskTimeoutMs: number): Promise<string> {

--- a/packages/cli/test/gemini-extract.test.ts
+++ b/packages/cli/test/gemini-extract.test.ts
@@ -14,7 +14,7 @@ The PR looks good. Changes are secure.`;
     expect(result).toContain("The PR looks good");
   });
 
-  test("returns last paragraph(s) as final answer", () => {
+  test("short output — returns single final paragraph, skips narration", () => {
     const raw = `YOLO mode is enabled. All tool calls will be automatically approved.
 
 I'll analyze the code.
@@ -24,7 +24,24 @@ I've completed the analysis.
 **Summary:** The changes are correct and secure. No issues found.`;
     const result = extractFinalAnswer(raw);
     expect(result).toContain("Summary");
-    expect(result).not.toContain("YOLO");
+    expect(result).not.toContain("I'll analyze");
+    expect(result).not.toContain("I've completed");
+  });
+
+  test("long output (>5 paragraphs) — returns up to 3 concluding paragraphs", () => {
+    const paragraphs = [
+      "I'll start reviewing.",
+      "Checking imports.",
+      "Looking at the logic.",
+      "Verifying tests.",
+      "Reviewing security.",
+      "All changes look correct.",
+      "No vulnerabilities found.",
+    ];
+    const raw = paragraphs.join("\n\n");
+    const result = extractFinalAnswer(raw);
+    expect(result).toContain("No vulnerabilities found");
+    expect(result).not.toContain("I'll start");
   });
 
   test("handles empty input", () => {
@@ -32,9 +49,15 @@ I've completed the analysis.
   });
 
   test("strips ANSI color codes", () => {
-    const raw = "\x1b[32mGreen text\x1b[0m\n\nFinal answer.";
+    const raw = "\u001b[32mGreen text\u001b[0m\n\nFinal answer.";
     const result = extractFinalAnswer(raw);
-    expect(result).not.toContain("\x1b");
+    expect(result).not.toContain("\u001b");
     expect(result).toContain("Final answer");
+  });
+
+  test("single paragraph — returns it regardless of narration prefix", () => {
+    const raw = "I've completed the task successfully.";
+    const result = extractFinalAnswer(raw);
+    expect(result).toBe("I've completed the task successfully.");
   });
 });


### PR DESCRIPTION
Follow-up to #189. The 3-paragraph heuristic grabbed thinking steps for short tasks.

Changes:
- Walk backward from last paragraph, skip narration openers (I'll, I've, Okay, etc.)
- Short outputs (≤5 paragraphs): return 1 final paragraph
- Long outputs (>5 paragraphs): return up to 3 concluding paragraphs
- 6 unit tests covering all cases

496/496 tests passing.