### PR TITLE
feat: per-model system prompt suffix for Gemini runtime (ops-95)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -430,6 +430,8 @@ async function main() {
               });
             } else if (runtimeArg === "gemini") {
               const { runGeminiRuntime } = await import("../src/utils/gemini-runtime.js");
+              const DEFAULT_GEMINI_SUFFIX =
+                "Be concise. Output only your final answer or conclusion. No thinking narration, no \"I\'ll do X\", no step-by-step commentary.";
               await runGeminiRuntime({
                 agentId: agentId!,
                 workspace: agentWorkspace,
@@ -440,6 +442,7 @@ async function main() {
                 flairUrl: agentCfg.flair?.url ?? process.env.FLAIR_URL,
                 flairKeyPath: agentCfg.flair?.keyPath,
                 workspaceProvider,
+                systemPromptSuffix: (agentCfg.gemini?.systemPromptSuffix as string | undefined) ?? DEFAULT_GEMINI_SUFFIX,
               });
             } else {
               const { runClaudeCodeRuntime } = await import("../src/utils/claude-code-runtime.js");

--- a/packages/cli/src/utils/gemini-runtime.ts
+++ b/packages/cli/src/utils/gemini-runtime.ts
@@ -36,6 +36,8 @@ export interface GeminiConfig {
   flairKeyPath: string;
   workspaceProvider?: WorkspaceProvider;
   pollIntervalMs?: number;
+  /** Appended to system prompt after soul/Flair context. Use for model-specific output instructions. */
+  systemPromptSuffix?: string;
 }
 
 interface MailMessage { id: string; from: string; to: string; body: string; timestamp: string; }
@@ -106,6 +108,9 @@ async function buildPrompt(message: MailMessage, config: GeminiConfig): Promise<
     } else {
       systemPrompt = `You are ${config.agentId}. Respond helpfully.`;
     }
+  }
+  if (config.systemPromptSuffix) {
+    systemPrompt += "\n\n" + config.systemPromptSuffix;
   }
   const userTask = `[Mail from: ${message.from}]\n${message.body}`;
   return { systemPrompt, userTask };


### PR DESCRIPTION
Addresses Nathan's token efficiency concern.

**Root cause:** Gemini outputs full thinking narration ("I'll do X...") before the final answer — those are output tokens already burned. `extractFinalAnswer` strips the display but can't recover spent tokens. Fix must be upstream in the prompt.

**Changes:**
- `GeminiConfig.systemPromptSuffix`: appended after soul/Flair context in `buildPrompt()`
- `tps.ts`: wires `agentCfg.gemini.systemPromptSuffix` from agent.yaml
- Default suffix: "Be concise. Output only your final answer. No thinking narration."
- Sherlock's `agent.yaml` gets review-specific instructions including `gh-as sherlock pr review --approve`

496/496 tests.