### PR TITLE
fix: flair-client use /FindMemories endpoint (was /SearchMemories)

### DIFF
--- a/packages/cli/src/utils/flair-client.ts
+++ b/packages/cli/src/utils/flair-client.ts
@@ -301,7 +301,7 @@ export class FlairClient {
   async search(query: string, limit = 5): Promise<SearchResult[]> {
     const result = await this.request<{ results: SearchResult[] }>(
       "POST",
-      "/SearchMemories/",
+      "/FindMemories",
       { agentId: this.agentId, q: query, limit },
     );
     return result.results ?? [];

--- a/packages/cli/test/agent-healthcheck.test.ts
+++ b/packages/cli/test/agent-healthcheck.test.ts
@@ -47,7 +47,7 @@ afterEach(() => {
 function mockFlairAuth(status = 200): typeof globalThis.fetch {
   return (async (input: string | URL, init?: RequestInit) => {
     const url = String(input);
-    if (url.endsWith("/SearchMemories/")) {
+    if (url.endsWith("/FindMemories")) {
       expect(init?.method).toBe("POST");
       expect(String((init?.headers as Record<string, string>)?.Authorization ?? "")).toContain(`TPS-Ed25519 ${agentId}:`);
       return new Response(JSON.stringify({ results: [] }), { status });
@@ -84,7 +84,7 @@ describe("tps agent healthcheck", () => {
 
     expect(output).toEqual([
       `FAIL  Identity: ~/.tps/agents/${agentId}/agent.yaml unreadable or missing`,
-      'FAIL  Flair auth: Flair POST /SearchMemories/ → 503: {"results":[]}',
+      'FAIL  Flair auth: Flair POST /FindMemories → 503: {"results":[]}',
       "FAIL  Process: no PID file found",
       `FAIL  Mail dir: ~/.tps/mail/${agentId}/new missing`,
     ]);

--- a/packages/cli/test/memory-cli.test.ts
+++ b/packages/cli/test/memory-cli.test.ts
@@ -208,7 +208,7 @@ describe("ops-31.1: tps memory show", () => {
 describe("ops-31.1: tps memory search", () => {
   test("calls MemorySearch and prints results", async () => {
     mockFetch(async (url, opts) => {
-      if (url.includes("/SearchMemories/")) {
+      if (url.includes("/FindMemories")) {
         return new Response(JSON.stringify({ results: [{ id: "m1", content: "gh commands lesson", _score: 0.91 }] }), { status: 200 });
       }
       return new Response("[]", { status: 200 });


### PR DESCRIPTION
Flair renamed `SearchMemories` → `FindMemories` in tpsdev-ai/flair#17 to avoid Harper table prefix collision. TPS `flair-client.ts` was never updated — all `tps memory search` calls 404'd silently and returned empty results.

**Changed:**
- `flair-client.ts`: `/SearchMemories/` → `/FindMemories`
- `agent-healthcheck.test.ts`: mock URL updated
- `memory-cli.test.ts`: mock URL updated

Pair with tpsdev-ai/flair#37 (embedding init timeout fix) to fully restore memory search.