### PR TITLE
fix: syncWorkspaceBeforeTask hard reset instead of rebase (ops-98)

### DIFF
--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -356,24 +356,38 @@ export async function syncWorkspaceBeforeTask(
   const warn = deps.warn ?? console.warn;
   const branch = resolveDefaultBranch(config.workspace, runSync);
 
-  // Always checkout default branch before rebase — task branches or detached HEAD both need this.
-  // Without explicit checkout, old task branches with conflict markers survive the rebase.
+  // Abort any in-progress rebase or merge before touching the worktree.
+  const rebaseMergeCheck = runSync(GIT_BIN, ["rebase", "--abort"], { cwd: config.workspace, encoding: "utf-8" });
+  if ((rebaseMergeCheck.status ?? 1) === 0) {
+    warn(`[${config.agentId}] Aborted stale in-progress rebase before sync.`);
+  }
+
+  // Checkout default branch — task branches or detached HEAD both need this.
   const checkoutResult = runSync(GIT_BIN, ["checkout", branch], { cwd: config.workspace, encoding: "utf-8" });
   if ((checkoutResult.status ?? 1) !== 0) {
     const stderr = typeof checkoutResult.stderr === "string" ? checkoutResult.stderr.trim() : "";
     warn(`[${config.agentId}] git checkout ${branch} failed (non-fatal): ${stderr}`);
   }
-  const result = runSync(GIT_BIN, ["pull", "--rebase", "origin", branch], {
+
+  // Fetch latest from origin.
+  runSync(GIT_BIN, ["fetch", "origin", branch], { cwd: config.workspace, encoding: "utf-8" });
+
+  // Hard reset to origin/<branch> — eliminates stale commits, conflict markers, and
+  // carried-over task-branch changes that survive rebases on dirty worktrees.
+  const resetResult = runSync(GIT_BIN, ["reset", "--hard", `origin/${branch}`], {
     cwd: config.workspace,
     encoding: "utf-8",
   });
+  if ((resetResult.status ?? 1) !== 0) {
+    const stderr = typeof resetResult.stderr === "string" ? resetResult.stderr.trim() : "";
+    warn(`[${config.agentId}] Workspace sync: git reset --hard failed (non-fatal): ${stderr}`);
+    return;
+  }
 
-  if ((result.status ?? 1) === 0) return;
+  // Remove untracked files and directories left by prior task branches.
+  runSync(GIT_BIN, ["clean", "-fd"], { cwd: config.workspace, encoding: "utf-8" });
 
-  const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
-  const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
-  const detail = stderr || stdout || `exit ${result.status ?? "unknown"}`;
-  warn(`[${config.agentId}] Workspace sync failed before task (non-fatal): git pull --rebase origin ${branch}: ${detail}`);
+  console.log(`[${config.agentId}] Workspace synced to origin/${branch}.`);
 }
 
 export async function runAutoCommit(

--- a/packages/cli/test/auto-commit.test.ts
+++ b/packages/cli/test/auto-commit.test.ts
@@ -244,29 +244,32 @@ describe("publishTaskOutcomeEvent", () => {
 });
 
 describe("syncWorkspaceBeforeTask", () => {
-  test("pulls with the configured remote default branch when origin HEAD is available", async () => {
+  test("hard-resets to origin/branch when origin HEAD is available", async () => {
     const calls: Array<{ cmd: string; args: string[] }> = [];
     const spawnSyncImpl = mock((cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      // All git commands succeed by default
+      return { status: 0, stdout: "", stderr: "" };
+    });
+
+    // Override symbolic-ref to return trunk
+    const origImpl = spawnSyncImpl.mock.calls;
+    const impl = mock((cmd: string, args: string[]) => {
       calls.push({ cmd, args });
       if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet --short refs/remotes/origin/HEAD") {
         return { status: 0, stdout: "origin/trunk\n", stderr: "" };
       }
-      if (cmd === "/usr/bin/git" && args.join(" ") === "checkout trunk") {
-        return { status: 0, stdout: "", stderr: "" };
-      }
-      if (cmd === "/usr/bin/git" && args.join(" ") === "pull --rebase origin trunk") {
-        return { status: 0, stdout: "", stderr: "" };
-      }
-      throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+      return { status: 0, stdout: "", stderr: "" };
     });
 
-    await syncWorkspaceBeforeTask(config, { spawnSyncImpl });
+    await syncWorkspaceBeforeTask(config, { spawnSyncImpl: impl });
 
-    expect(calls).toEqual([
-      { cmd: "/usr/bin/git", args: ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"] },
-      { cmd: "/usr/bin/git", args: ["checkout", "trunk"] },
-      { cmd: "/usr/bin/git", args: ["pull", "--rebase", "origin", "trunk"] },
-    ]);
+    // Must include: rebase --abort, checkout, fetch, reset --hard, clean -fd
+    expect(calls.some(c => c.args.join(" ") === "rebase --abort")).toBe(true);
+    expect(calls.some(c => c.args.join(" ") === "checkout trunk")).toBe(true);
+    expect(calls.some(c => c.args.join(" ") === "fetch origin trunk")).toBe(true);
+    expect(calls.some(c => c.args.join(" ") === "reset --hard origin/trunk")).toBe(true);
+    expect(calls.some(c => c.args.join(" ") === "clean -fd")).toBe(true);
   });
 
   test("falls back to main when origin HEAD is not configured", async () => {
@@ -276,44 +279,31 @@ describe("syncWorkspaceBeforeTask", () => {
       if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet --short refs/remotes/origin/HEAD") {
         return { status: 1, stdout: "", stderr: "" };
       }
-      if (cmd === "/usr/bin/git" && args.join(" ") === "checkout main") {
-        return { status: 0, stdout: "", stderr: "" };
-      }
-      if (cmd === "/usr/bin/git" && args.join(" ") === "pull --rebase origin main") {
-        return { status: 0, stdout: "", stderr: "" };
-      }
-      throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+      return { status: 0, stdout: "", stderr: "" };
     });
 
     await syncWorkspaceBeforeTask(config, { spawnSyncImpl });
 
-    expect(calls).toEqual([
-      { cmd: "/usr/bin/git", args: ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"] },
-      { cmd: "/usr/bin/git", args: ["checkout", "main"] },
-      { cmd: "/usr/bin/git", args: ["pull", "--rebase", "origin", "main"] },
-    ]);
+    expect(calls.some(c => c.args.join(" ") === "checkout main")).toBe(true);
+    expect(calls.some(c => c.args.join(" ") === "reset --hard origin/main")).toBe(true);
   });
 
-  test("warns and continues when rebase fails", async () => {
+  test("warns and continues when reset fails", async () => {
     const warn = mock(() => {});
     const spawnSyncImpl = mock((cmd: string, args: string[]) => {
       if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet --short refs/remotes/origin/HEAD") {
         return { status: 0, stdout: "origin/main\n", stderr: "" };
       }
-      if (cmd === "/usr/bin/git" && args.join(" ") === "checkout main") {
-        return { status: 0, stdout: "", stderr: "" };
+      if (cmd === "/usr/bin/git" && args.join(" ") === "reset --hard origin/main") {
+        return { status: 1, stdout: "", stderr: "fatal: cannot reset" };
       }
-      if (cmd === "/usr/bin/git" && args.join(" ") === "pull --rebase origin main") {
-        return { status: 1, stdout: "", stderr: "cannot rebase: unstaged changes" };
-      }
-      throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+      return { status: 0, stdout: "", stderr: "" };
     });
 
     await syncWorkspaceBeforeTask(config, { spawnSyncImpl, warn });
 
-    expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
-      "[ember] Workspace sync failed before task (non-fatal): git pull --rebase origin main: cannot rebase: unstaged changes",
+      expect.stringContaining("git reset --hard failed"),
     );
   });
 });


### PR DESCRIPTION
**Root cause:** Ember's worktree accumulates stale task-branch commits across runs. `git pull --rebase` fails or silently carries over prior changes when the worktree is dirty, causing:
- Conflict markers in diffs
- Out-of-scope files in PRs (stale carry-over from prior tasks)
- autoCommit push silently failing

**Fix:** Replace rebase with hard reset sequence:
```
git rebase --abort          # clear any stale in-progress rebase
git checkout <branch>       # leave task branch
git fetch origin <branch>   # get latest
git reset --hard origin/<branch>  # clean slate
git clean -fd               # remove untracked files
```

**Tests:** 3 updated tests covering hard reset, fallback to main, and reset failure warning. 496 tests pass.