### PR TITLE
fix: autoCommit exit code mismatch on new task branches (ops-100)

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -894,8 +894,18 @@ async function commitAgentChanges(args: AgentArgs): Promise<void> {
   const diff = runGit(["diff", "--cached", "--quiet"], repoPath);
   if (diff.status === 0) {
     // Nothing staged — check if HEAD is already ahead of origin (agent self-committed)
-    const ahead = runGit(["rev-list", "--count", `origin/${branchName!}..HEAD`], repoPath);
-    const aheadCount = parseInt((ahead.stdout ?? "").trim(), 10);
+    // Note: origin/<branch> may not exist yet if this is the first push.
+    const refExists = runGit(["rev-parse", "--verify", `refs/remotes/origin/${branchName!}`], repoPath).ok;
+    let aheadCount = 0;
+    if (refExists) {
+      const ahead = runGit(["rev-list", "--count", `origin/${branchName!}..HEAD`], repoPath);
+      aheadCount = parseInt((ahead.stdout ?? "").trim(), 10);
+    } else {
+      // Branch not yet pushed — count local commits; any commit means already committed
+      const localCommits = runGit(["rev-list", "--count", "HEAD"], repoPath);
+      const localCount = parseInt((localCommits.stdout ?? "").trim(), 10);
+      aheadCount = Number.isNaN(localCount) ? 0 : localCount;
+    }
     if (Number.isNaN(aheadCount) || aheadCount === 0) {
       failWith("No changes staged for commit.");
     }


### PR DESCRIPTION
Fixes a latent bug in `tps agent commit`'s 'already committed' detection.

**The bug:** When a task branch has never been pushed, `git rev-list --count origin/<branch>..HEAD` fails because `refs/remotes/origin/<branch>` doesn't exist. This makes `aheadCount` NaN, causing the command to exit 1 with 'No changes staged for commit' — even when the commit is real.

**Note:** This was NOT the cause of today's Ember incident (that was a genuine no-op — Codex explored 40 turns without writing files). But this bug would fire if Ember self-commits and then autoCommit re-runs on the same branch before a push.

**Fix:** Check if the remote ref exists. If not, count local HEAD commits as the ahead proxy.