### PR TITLE
fix: update flair client to use /SemanticSearch endpoint

### DIFF
--- a/packages/cli/src/commands/flair-health.ts
+++ b/packages/cli/src/commands/flair-health.ts
@@ -5,7 +5,7 @@
  *   1. HTTP reachability
  *   2. Memory write (PUT /Memory/<test-id>)
  *   3. Memory read-back (GET /Memory/<test-id>)
- *   4. Semantic search roundtrip (POST /MemoryQuery)
+ *   4. Semantic search roundtrip (POST /SemanticSearch)
  *   5. Memory cleanup (DELETE /Memory/<test-id>)
  *
  * Exits 0 if all pass, 1 if any fail.

--- a/packages/cli/src/utils/flair-client.ts
+++ b/packages/cli/src/utils/flair-client.ts
@@ -301,7 +301,7 @@ export class FlairClient {
   async search(query: string, limit = 5): Promise<SearchResult[]> {
     const result = await this.request<{ results: SearchResult[] }>(
       "POST",
-      "/MemoryQuery",
+      "/SemanticSearch",
       { agentId: this.agentId, q: query, limit },
     );
     return result.results ?? [];

--- a/packages/cli/test/agent-healthcheck.test.ts
+++ b/packages/cli/test/agent-healthcheck.test.ts
@@ -47,7 +47,7 @@ afterEach(() => {
 function mockFlairAuth(status = 200): typeof globalThis.fetch {
   return (async (input: string | URL, init?: RequestInit) => {
     const url = String(input);
-    if (url.endsWith("/MemoryQuery")) {
+    if (url.endsWith("/SemanticSearch")) {
       expect(init?.method).toBe("POST");
       expect(String((init?.headers as Record<string, string>)?.Authorization ?? "")).toContain(`TPS-Ed25519 ${agentId}:`);
       return new Response(JSON.stringify({ results: [] }), { status });
@@ -84,7 +84,7 @@ describe("tps agent healthcheck", () => {
 
     expect(output).toEqual([
       `FAIL  Identity: ~/.tps/agents/${agentId}/agent.yaml unreadable or missing`,
-      'FAIL  Flair auth: Flair POST /MemoryQuery → 503: {"results":[]}',
+      'FAIL  Flair auth: Flair POST /SemanticSearch → 503: {"results":[]}',
       "FAIL  Process: no PID file found",
       `FAIL  Mail dir: ~/.tps/mail/${agentId}/new missing`,
     ]);

--- a/packages/cli/test/memory-cli.test.ts
+++ b/packages/cli/test/memory-cli.test.ts
@@ -208,7 +208,7 @@ describe("ops-31.1: tps memory show", () => {
 describe("ops-31.1: tps memory search", () => {
   test("calls MemorySearch and prints results", async () => {
     mockFetch(async (url, opts) => {
-      if (url.includes("/MemoryQuery")) {
+      if (url.includes("/SemanticSearch")) {
         return new Response(JSON.stringify({ results: [{ id: "m1", content: "gh commands lesson", _score: 0.91 }] }), { status: 200 });
       }
       return new Response("[]", { status: 200 });


### PR DESCRIPTION
Harper v5 routes POST requests to the table handler when a custom resource name starts with a table name prefix. `MemoryQuery` → `Memory` table collision.

Updates `flair-client.ts`, `flair-health.ts`, and tests to use `/SemanticSearch`.

Companion to flair#40.