### PR TITLE
feat: honor agent.yaml systemPrompt in codex runtime

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -434,6 +434,7 @@ async function main() {
                 watchdogTimeoutMs: agentCfg.codex?.watchdogTimeoutMs,
                 flairUrl: agentCfg.flair?.url ?? process.env.FLAIR_URL,
                 flairKeyPath: agentCfg.flair?.keyPath,
+                systemPrompt: typeof agentCfg.systemPrompt === "string" ? agentCfg.systemPrompt : undefined,
                 workspaceProvider,
                 autoCommit: agentCfg.autoCommit,
               });

--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -109,6 +109,7 @@ export interface CodexRuntimeConfig {
   sessionLogPath?: string;
   flairUrl?: string;
   flairKeyPath: string;
+  systemPrompt?: string;
   workspaceProvider?: WorkspaceProvider;
   /** If set, auto-commit workspace changes after each task completes */
   autoCommit?: AutoCommitConfig;
@@ -163,6 +164,21 @@ function sendMail(mailDir: string, from: string, to: string, body: string): void
   renameSync(tmpPath, newPath);
 }
 
+export function composeSystemPrompt(
+  flairSystemPrompt: string,
+  configSystemPrompt?: string,
+  experience?: string,
+): string {
+  let systemPrompt = flairSystemPrompt;
+  if (configSystemPrompt) {
+    systemPrompt += "\n\n" + configSystemPrompt;
+  }
+  if (experience) {
+    systemPrompt += "\n\n" + experience;
+  }
+  return systemPrompt;
+}
+
 async function buildSystemPrompt(
   message: MailMessage,
   config: CodexRuntimeConfig,
@@ -175,7 +191,7 @@ async function buildSystemPrompt(
     { allowedTools, supervisorId },
   );
   const experience = await searchPastExperience(flair, message.body, workspace);
-  return experience ? systemPrompt + "\n\n" + experience : systemPrompt;
+  return composeSystemPrompt(systemPrompt, config.systemPrompt, experience);
 }
 
 interface RunCodexOptions {

--- a/packages/cli/test/auto-commit.test.ts
+++ b/packages/cli/test/auto-commit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
+  composeSystemPrompt,
   publishTaskOutcomeEvent,
   runAutoCommit,
   syncWorkspaceBeforeTask,
@@ -11,6 +12,18 @@ const config: CodexRuntimeConfig = {
   workspace: "/tmp/repo",
   mailDir: "/tmp/mail",
 };
+
+describe("composeSystemPrompt", () => {
+  test("appends config systemPrompt before past experience", () => {
+    const result = composeSystemPrompt(
+      "Flair soul",
+      "Agent YAML instructions",
+      "Past experience",
+    );
+
+    expect(result).toBe("Flair soul\n\nAgent YAML instructions\n\nPast experience");
+  });
+});
 
 describe("runAutoCommit", () => {
   test("creates the branch before invoking tps agent commit when HEAD is detached", async () => {


### PR DESCRIPTION
## Summary
- pass  from agent.yaml into the Codex runtime
- append agent config prompt after Flair boot context and before past experience
- add a regression test for prompt composition ordering

## Testing
- bun test packages/cli/test/auto-commit.test.ts