### PR TITLE
fix: keep pulse alive under launchd

### DIFF
--- a/packages/cli/src/commands/pulse.ts
+++ b/packages/cli/src/commands/pulse.ts
@@ -473,9 +473,18 @@ export function makeFlairPublisher(config: PulseConfig): FlairPublisher | undefi
 export async function startPollLoop(
   config: PulseConfig,
   state: PulseState,
-  opts: { dryRun?: boolean; runner?: SyncRunner; sender?: MailSender; publisher?: FlairPublisher } = {},
+  opts: {
+    dryRun?: boolean;
+    runner?: SyncRunner;
+    sender?: MailSender;
+    publisher?: FlairPublisher;
+    setIntervalFn?: typeof setInterval;
+    clearIntervalFn?: typeof clearInterval;
+  } = {},
 ): Promise<void> {
   const runner = opts.runner ?? (spawnSync as unknown as SyncRunner);
+  const setIntervalFn = opts.setIntervalFn ?? setInterval;
+  const clearIntervalFn = opts.clearIntervalFn ?? clearInterval;
   const sender = opts.dryRun
     ? (to: string, body: string, _agentId: string) => {
         console.log(`[pulse/dry-run] would mail ${to}: ${body.slice(0, 80)}…`);
@@ -501,12 +510,14 @@ export async function startPollLoop(
   poll();
 
   // Then on interval
-  const handle = setInterval(poll, config.pollIntervalMs);
+  const handle = setIntervalFn(poll, config.pollIntervalMs);
+  const keepalive = setIntervalFn(() => {}, 1 << 30);
 
   // Graceful shutdown
   await new Promise<void>((resolve) => {
     const stop = () => {
-      clearInterval(handle);
+      clearIntervalFn(handle);
+      clearIntervalFn(keepalive);
       saveState(state);
       console.log("[pulse] Stopped.");
       resolve();

--- a/packages/cli/test/pulse.test.ts
+++ b/packages/cli/test/pulse.test.ts
@@ -5,6 +5,7 @@ import {
   checkReminders,
   pollOnce,
   pruneState,
+  startPollLoop,
   type PrInstance,
   type PrState,
   type PulseConfig,
@@ -417,6 +418,49 @@ describe("pruneState", () => {
 // ---------------------------------------------------------------------------
 // Flair publisher (handleTransition integration)
 // ---------------------------------------------------------------------------
+
+describe("startPollLoop", () => {
+  test("does not resolve immediately after the first poll", async () => {
+    const config = makeConfig({ pollIntervalMs: 120000 });
+    const state = makeState();
+
+    let pollCalls = 0;
+    const runner: SyncRunner = (_cmd, args) => {
+      const endpoint = args[2];
+      if (endpoint?.includes("/pulls?")) {
+        pollCalls++;
+      }
+      return { status: 0, stdout: "[]", stderr: "" } as ReturnType<SyncRunner>;
+    };
+
+    const handles: Array<{ fn: () => void }> = [];
+    const setIntervalFn: typeof setInterval = ((fn: TimerHandler) => {
+      handles.push({ fn: fn as () => void });
+      return handles.length as unknown as ReturnType<typeof setInterval>;
+    }) as typeof setInterval;
+    const clearIntervalFn: typeof clearInterval = (() => {}) as typeof clearInterval;
+
+    let resolved = false;
+    const loopPromise = startPollLoop(config, state, {
+      dryRun: true,
+      runner,
+      setIntervalFn,
+      clearIntervalFn,
+    }).then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+
+    expect(pollCalls).toBe(1);
+    expect(handles).toHaveLength(2);
+    expect(resolved).toBe(false);
+
+    process.emit("SIGTERM");
+    await loopPromise;
+    expect(resolved).toBe(true);
+  });
+});
 
 describe("FlairPublisher integration", () => {
   test("publisher is called on transition", async () => {


### PR DESCRIPTION
## Summary
- add a keepalive timer in pulse startPollLoop so Bun stays alive under launchd
- clear the keepalive timer on shutdown alongside the poll interval
- add a regression test proving startPollLoop stays pending after the first poll

## Testing
- bun test packages/cli/test/pulse.test.ts