### PR TITLE
fix: reuse codex-created commits in autocommit

### DIFF
--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -336,6 +336,10 @@ export interface WorkspaceSyncDeps {
   warn?: (message?: any, ...optionalParams: any[]) => void;
 }
 
+export function hasWorkspaceChangesOrNewCommit(statusOutput: string, baseline?: string | null, currentHead?: string | null): boolean {
+  return statusOutput.trim().length > 0 || currentHead !== baseline;
+}
+
 interface AutoCommitFlair {
   publishEvent(event: { kind: string; summary: string; detail?: string; refId?: string }): Promise<void>;
 }
@@ -751,6 +755,7 @@ export async function runCodexRuntime(config: CodexRuntimeConfig): Promise<void>
         const flairPub2 = { publishEvent: async (ev: Record<string, unknown>) => {
           try { await (flair as any).request("POST", "/OrgEvent", { ...ev, authorId: agentId }); } catch { /* non-fatal */ }
         }};
+        const baseline = spawnSync(GIT_BIN, ["rev-parse", "HEAD"], { cwd: config.workspace, encoding: "utf-8" }).stdout?.trim();
         const result = await runCodex(msg, config, config.taskTimeoutMs ?? 30 * 60 * 1000, {
           flairPublisher: flairPub2,
           onStall: () => { sendMail(mailDir, agentId, msg.from, `Task stalled: no Codex output for ${Math.round((config.watchdogTimeoutMs ?? 300000) / 60000)}m — process killed. Please resend the task.`); },
@@ -799,9 +804,10 @@ export async function runCodexRuntime(config: CodexRuntimeConfig): Promise<void>
             console.warn(`[${agentId}] Stale rebase state detected before autoCommit — aborting rebase and proceeding`);
             spawnSync(GIT_BIN, ["rebase", "--abort"], { cwd: config.workspace, encoding: "utf-8" });
           }
-          // Check for file changes before attempting autoCommit
+          // Check for file changes or Codex-created commits before attempting autoCommit
           const gitStatusResult = spawnSync(GIT_BIN, ["status", "--porcelain"], { cwd: config.workspace, encoding: "utf-8" });
-          const hasChanges = (gitStatusResult.stdout ?? "").trim().length > 0;
+          const currentHead = spawnSync(GIT_BIN, ["rev-parse", "HEAD"], { cwd: config.workspace, encoding: "utf-8" }).stdout?.trim();
+          const hasChanges = hasWorkspaceChangesOrNewCommit(gitStatusResult.stdout ?? "", baseline, currentHead);
           if (!hasChanges) {
             console.warn(`[${agentId}] Task produced no file changes — skipping autoCommit`);
             sendMail(mailDir, agentId, msg.from,

--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -415,6 +415,74 @@ export async function syncWorkspaceBeforeTask(
   console.log(`[${config.agentId}] Workspace synced to origin/${branch}.`);
 }
 
+function openPullRequest(
+  runSync: typeof spawnSync,
+  flair: AutoCommitFlair,
+  options: AutoCommitOptions,
+  authorEmail: string,
+  repo: string,
+): Promise<void> {
+  const {
+    taskId,
+    branchName,
+    commitMessage,
+    prRepo,
+    ghAgent,
+    prTitle,
+    prBody,
+    authorName,
+  } = options;
+
+  return (async () => {
+    if (!options.push || !options.openPr || !prRepo) return;
+    const prArgs = [
+      ghAgent ?? authorEmail.split("@")[0] ?? "",
+      "pr",
+      "create",
+      "--repo",
+      prRepo,
+      "--head",
+      branchName,
+      "--title", prTitle ?? `task: ${taskId}`,
+      "--body",
+      prBody ?? commitMessage,
+    ];
+    console.log(`[autoCommit] opening PR: gh-as ${prArgs[0]} pr create --repo ${prRepo} --head ${branchName}`);
+    const prResult = runSync("gh-as", prArgs, { cwd: repo, encoding: "utf-8" });
+    const prStdout2 = typeof prResult.stdout === "string" ? prResult.stdout.trim() : "";
+    const prStderr2 = typeof prResult.stderr === "string" ? prResult.stderr.trim() : "";
+    console.log(`[autoCommit] gh-as pr create exit=${prResult.status} stdout=${prStdout2.slice(0, 200)}`);
+    if (prStderr2) console.log(`[autoCommit] gh-as stderr: ${prStderr2.slice(0, 200)}`);
+    if ((prResult.status ?? 1) === 0) {
+      const prUrl = prStdout2.trim();
+      const prNumber = prUrl.match(/\/pull\/(\d+)/)?.[1] ?? "?";
+      if (options.reviewNotify?.length && options.mailDir) {
+        for (const reviewer of options.reviewNotify) {
+          try {
+            const { sendMessage } = await import("../utils/mail.js");
+            sendMessage(reviewer, `PR #${prNumber} for review: ${prUrl}`, authorName.toLowerCase());
+            console.log(`[autoCommit] Notified reviewer: ${reviewer} (PR #${prNumber})`);
+          } catch (notifyErr: any) {
+            console.warn(`[autoCommit] Failed to notify ${reviewer}: ${notifyErr.message}`);
+          }
+        }
+      }
+      return;
+    }
+
+    const prErrMsg = prStderr2 || prStdout2 || `exit ${prResult.status ?? "unknown"}`;
+    try {
+      await flair.publishEvent({
+        kind: "blocker",
+        summary: `PR creation failed for ${taskId}`,
+        detail: prErrMsg,
+        refId: taskId,
+      });
+    } catch { /* non-fatal */ }
+    throw new Error(`gh-as pr create failed: ${prErrMsg}`);
+  })();
+}
+
 export async function runAutoCommit(
   config: Pick<CodexRuntimeConfig, "workspace">,
   flair: AutoCommitFlair,
@@ -448,6 +516,34 @@ export async function runAutoCommit(
     }
   }
 
+  const statusResult = runSync(GIT_BIN, ["status", "--porcelain"], { cwd: repo, encoding: "utf-8" });
+  const hasWorkingTreeChanges = ((statusResult.stdout ?? "") as string).trim().length > 0;
+  const remoteRefCheck = runSync(GIT_BIN, ["rev-parse", "--verify", `refs/remotes/origin/${branchName}`], { cwd: repo, encoding: "utf-8" });
+  const aheadResult = runSync(
+    GIT_BIN,
+    ["rev-list", "--count", remoteRefCheck.status === 0 ? `origin/${branchName}..HEAD` : "HEAD"],
+    { cwd: repo, encoding: "utf-8" },
+  );
+  const aheadCount = parseInt(((aheadResult.stdout ?? "") as string).trim(), 10);
+  const hasExistingCommits = !Number.isNaN(aheadCount) && aheadCount > 0;
+
+  if (!hasWorkingTreeChanges && hasExistingCommits) {
+    console.log(`[autoCommit] reusing existing commits on ${branchName}`);
+    if (push) {
+      const pushResult = runSync(GIT_BIN, ["push", "-u", "origin", branchName], { cwd: repo, encoding: "utf-8" });
+      const pushStdout = typeof pushResult.stdout === "string" ? pushResult.stdout.trim() : "";
+      const pushStderr = typeof pushResult.stderr === "string" ? pushResult.stderr.trim() : "";
+      console.log(`[autoCommit] git push exit=${pushResult.status} branch=${branchName}`);
+      if (pushStdout) console.log(`[autoCommit] push stdout: ${pushStdout.slice(0, 200)}`);
+      if (pushStderr) console.log(`[autoCommit] push stderr: ${pushStderr.slice(0, 200)}`);
+      if ((pushResult.status ?? 1) !== 0) {
+        throw new Error(`git push failed: ${pushStderr || pushStdout || `exit ${pushResult.status ?? "unknown"}`}`);
+      }
+    }
+    await openPullRequest(runSync, flair, options, authorEmail, repo);
+    return;
+  }
+
   const args = [
     "agent", "commit",
     "--repo", repo,
@@ -465,55 +561,7 @@ export async function runAutoCommit(
   if (resultStdout) console.log(`[autoCommit] stdout: ${resultStdout.slice(0, 200)}`);
   if (resultStderr) console.log(`[autoCommit] stderr: ${resultStderr.slice(0, 200)}`);
   if (result.status === 0) {
-    if (push && openPr && prRepo) {
-      const prArgs = [
-        ghAgent ?? authorEmail.split("@")[0] ?? "",
-        "pr",
-        "create",
-        "--repo",
-        prRepo,
-        "--head",
-        branchName,
-        "--title", prTitle ?? `task: ${taskId}`,
-        "--body",
-        prBody ?? commitMessage,
-      ];
-      console.log(`[autoCommit] opening PR: gh-as ${prArgs[0]} pr create --repo ${prRepo} --head ${branchName}`);
-      const prResult = runSync("gh-as", prArgs, { cwd: repo, encoding: "utf-8" });
-      const prStdout2 = typeof prResult.stdout === "string" ? prResult.stdout.trim() : "";
-      const prStderr2 = typeof prResult.stderr === "string" ? prResult.stderr.trim() : "";
-      console.log(`[autoCommit] gh-as pr create exit=${prResult.status} stdout=${prStdout2.slice(0, 200)}`);
-      if (prStderr2) console.log(`[autoCommit] gh-as stderr: ${prStderr2.slice(0, 200)}`);
-      if ((prResult.status ?? 1) === 0) {
-        const prUrl = prStdout2.trim();
-        const prNumber = prUrl.match(/\/pull\/(\d+)/)?.[1] ?? "?";
-        if (options.reviewNotify?.length && options.mailDir) {
-          for (const reviewer of options.reviewNotify) {
-            try {
-              const { sendMessage } = await import("../utils/mail.js");
-              sendMessage(reviewer, `PR #${prNumber} for review: ${prUrl}`, authorName.toLowerCase());
-              console.log(`[autoCommit] Notified reviewer: ${reviewer} (PR #${prNumber})`);
-            } catch (notifyErr: any) {
-              console.warn(`[autoCommit] Failed to notify ${reviewer}: ${notifyErr.message}`);
-            }
-          }
-        }
-        return;
-      }
-
-      const prStderr = prStderr2;
-      const prStdout = prStdout2;
-      const prErrMsg = prStderr || prStdout || `exit ${prResult.status ?? "unknown"}`;
-      try {
-        await flair.publishEvent({
-          kind: "blocker",
-          summary: `PR creation failed for ${taskId}`,
-          detail: prErrMsg,
-          refId: taskId,
-        });
-      } catch { /* non-fatal */ }
-      throw new Error(`gh-as pr create failed: ${prErrMsg}`);
-    }
+    await openPullRequest(runSync, flair, options, authorEmail, repo);
     return;
   }
 

--- a/packages/cli/test/auto-commit.test.ts
+++ b/packages/cli/test/auto-commit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
   composeSystemPrompt,
+  hasWorkspaceChangesOrNewCommit,
   publishTaskOutcomeEvent,
   runAutoCommit,
   syncWorkspaceBeforeTask,
@@ -22,6 +23,14 @@ describe("composeSystemPrompt", () => {
     );
 
     expect(result).toBe("Flair soul\n\nAgent YAML instructions\n\nPast experience");
+  });
+});
+
+describe("hasWorkspaceChangesOrNewCommit", () => {
+  test("detects a new HEAD commit even when the working tree is clean", () => {
+    expect(hasWorkspaceChangesOrNewCommit("", "abc123", "def456")).toBe(true);
+    expect(hasWorkspaceChangesOrNewCommit("", "abc123", "abc123")).toBe(false);
+    expect(hasWorkspaceChangesOrNewCommit(" M file.ts", "abc123", "abc123")).toBe(true);
   });
 });
 

--- a/packages/cli/test/auto-commit.test.ts
+++ b/packages/cli/test/auto-commit.test.ts
@@ -45,6 +45,15 @@ describe("runAutoCommit", () => {
       if (cmd === "/usr/bin/git" && args.join(" ") === "checkout -b feat/task-123") {
         return { status: 0, stdout: "", stderr: "" };
       }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "status --porcelain") {
+        return { status: 0, stdout: " M file.ts\n", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "rev-parse --verify refs/remotes/origin/feat/task-123") {
+        return { status: 1, stdout: "", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "rev-list --count HEAD") {
+        return { status: 0, stdout: "0\n", stderr: "" };
+      }
       if (cmd === "tps") {
         return { status: 0, stdout: "", stderr: "" };
       }
@@ -69,6 +78,9 @@ describe("runAutoCommit", () => {
     expect(calls).toEqual([
       { cmd: "/usr/bin/git", args: ["symbolic-ref", "--quiet", "HEAD"] },
       { cmd: "/usr/bin/git", args: ["checkout", "-b", "feat/task-123"] },
+      { cmd: "/usr/bin/git", args: ["status", "--porcelain"] },
+      { cmd: "/usr/bin/git", args: ["rev-parse", "--verify", "refs/remotes/origin/feat/task-123"] },
+      { cmd: "/usr/bin/git", args: ["rev-list", "--count", "HEAD"] },
       {
         cmd: "tps",
         args: [
@@ -97,6 +109,15 @@ describe("runAutoCommit", () => {
       calls.push({ cmd, args });
       if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet HEAD") {
         return { status: 0, stdout: "refs/heads/feat/task-456\n", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "status --porcelain") {
+        return { status: 0, stdout: " M file.ts\n", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "rev-parse --verify refs/remotes/origin/feat/task-456") {
+        return { status: 1, stdout: "", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "rev-list --count HEAD") {
+        return { status: 0, stdout: "0\n", stderr: "" };
       }
       if (cmd === "tps") {
         return { status: 0, stdout: "", stderr: "" };
@@ -127,6 +148,9 @@ describe("runAutoCommit", () => {
 
     expect(calls).toEqual([
       { cmd: "/usr/bin/git", args: ["symbolic-ref", "--quiet", "HEAD"] },
+      { cmd: "/usr/bin/git", args: ["status", "--porcelain"] },
+      { cmd: "/usr/bin/git", args: ["rev-parse", "--verify", "refs/remotes/origin/feat/task-456"] },
+      { cmd: "/usr/bin/git", args: ["rev-list", "--count", "HEAD"] },
       {
         cmd: "tps",
         args: [
@@ -163,11 +187,91 @@ describe("runAutoCommit", () => {
     ]);
   });
 
+  test("pushes existing commits and opens a PR when Codex already committed", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const spawnSyncImpl = mock((cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet HEAD") {
+        return { status: 0, stdout: "refs/heads/feat/task-789\n", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "status --porcelain") {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "rev-parse --verify refs/remotes/origin/feat/task-789") {
+        return { status: 0, stdout: "originref\n", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "rev-list --count origin/feat/task-789..HEAD") {
+        return { status: 0, stdout: "1\n", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "push -u origin feat/task-789") {
+        return { status: 0, stdout: "pushed\n", stderr: "" };
+      }
+      if (cmd === "gh-as") {
+        return { status: 0, stdout: "https://github.com/tpsdev-ai/cli/pull/789\n", stderr: "" };
+      }
+      if (cmd === "tps") {
+        throw new Error("tps agent commit should not run when reusing existing commits");
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+    });
+
+    await runAutoCommit(
+      config,
+      { publishEvent: mock(async () => {}) },
+      {
+        taskId: "task-789",
+        branchName: "feat/task-789",
+        commitMessage: "feat: ship task 789",
+        authorName: "Ember",
+        authorEmail: "ember@tps.dev",
+        push: true,
+        openPr: true,
+        prRepo: "tpsdev-ai/cli",
+        ghAgent: "ember",
+        prTitle: "feat: ship task 789",
+      },
+      { spawnSyncImpl },
+    );
+
+    expect(calls).toEqual([
+      { cmd: "/usr/bin/git", args: ["symbolic-ref", "--quiet", "HEAD"] },
+      { cmd: "/usr/bin/git", args: ["status", "--porcelain"] },
+      { cmd: "/usr/bin/git", args: ["rev-parse", "--verify", "refs/remotes/origin/feat/task-789"] },
+      { cmd: "/usr/bin/git", args: ["rev-list", "--count", "origin/feat/task-789..HEAD"] },
+      { cmd: "/usr/bin/git", args: ["push", "-u", "origin", "feat/task-789"] },
+      {
+        cmd: "gh-as",
+        args: [
+          "ember",
+          "pr",
+          "create",
+          "--repo",
+          "tpsdev-ai/cli",
+          "--head",
+          "feat/task-789",
+          "--title",
+          "feat: ship task 789",
+          "--body",
+          "feat: ship task 789",
+        ],
+      },
+    ]);
+  });
+
   test("publishes a blocker OrgEvent when runtime PR creation fails", async () => {
     const publishEvent = mock(async () => {});
     const spawnSyncImpl = mock((cmd: string, args: string[]) => {
       if (cmd === "/usr/bin/git" && args.join(" ") === "symbolic-ref --quiet HEAD") {
         return { status: 0, stdout: "refs/heads/feat/task-456\n", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "status --porcelain") {
+        return { status: 0, stdout: " M file.ts\n", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "rev-parse --verify refs/remotes/origin/feat/task-456") {
+        return { status: 1, stdout: "", stderr: "" };
+      }
+      if (cmd === "/usr/bin/git" && args.join(" ") === "rev-list --count HEAD") {
+        return { status: 0, stdout: "0\n", stderr: "" };
       }
       if (cmd === "tps") {
         return { status: 0, stdout: "", stderr: "" };


### PR DESCRIPTION
## Summary
- detect when Codex already created commits on the task branch
- push existing commits and open the PR without creating a duplicate commit
- add a regression test for clean-tree existing-commit autoCommit behavior

## Testing
- bun test packages/cli/test/auto-commit.test.ts