### PR TITLE
Add --json flag to 'tps pulse status' command.

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -1005,6 +1005,7 @@ async function main() {
         action: (rest[0] as "start" | "status" | "list" | undefined) ?? "start",
         dryRun: Boolean(cli.flags["dry-run"]),
         interval: cli.flags.interval ? Number(cli.flags.interval) : undefined,
+        json: Boolean(cli.flags.json),
         repo: cli.flags.repo as string | undefined,
       });
       break;

--- a/packages/cli/src/commands/pulse.ts
+++ b/packages/cli/src/commands/pulse.ts
@@ -531,13 +531,22 @@ export async function startPollLoop(
 // Subcommands
 // ---------------------------------------------------------------------------
 
-function printStatus(): void {
-  const state = loadState();
+export function printStatus(args: Pick<PulseArgs, "json"> = {}, state = loadState()): void {
   if (!state.lastPollAt) {
     console.log("Pulse has not run yet.");
     return;
   }
   const active = Object.values(state.instances).filter((i) => i.state !== "merged");
+  if (args.json) {
+    console.log(
+      JSON.stringify({
+        lastPollAt: state.lastPollAt,
+        activeCount: active.length,
+        active,
+      }),
+    );
+    return;
+  }
   console.log(`Last poll: ${state.lastPollAt}`);
   console.log(`Active PRs: ${active.length}`);
   for (const inst of active) {
@@ -567,6 +576,7 @@ export interface PulseArgs {
   repo?: string;
   interval?: number;
   dryRun?: boolean;
+  json?: boolean;
 }
 
 export async function runPulse(args: PulseArgs): Promise<void> {
@@ -584,7 +594,7 @@ export async function runPulse(args: PulseArgs): Promise<void> {
       break;
     }
     case "status": {
-      printStatus();
+      printStatus({ json: args.json });
       break;
     }
     case "list": {

--- a/packages/cli/test/pulse.test.ts
+++ b/packages/cli/test/pulse.test.ts
@@ -4,6 +4,7 @@ import {
   handleTransition,
   checkReminders,
   pollOnce,
+  printStatus,
   pruneState,
   startPollLoop,
   type PrInstance,
@@ -243,6 +244,32 @@ describe("checkReminders", () => {
     checkReminders(state, config, sender);
 
     expect(calls.length).toBe(0);
+  });
+});
+
+describe("printStatus", () => {
+  test("prints JSON status when requested", () => {
+    const state = makeState({
+      "pr:tpsdev-ai/cli#42": makeInstance(),
+    });
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (value?: unknown) => {
+      logs.push(String(value));
+    };
+
+    try {
+      printStatus({ json: true }, state);
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(logs).toHaveLength(1);
+    const parsed = JSON.parse(logs[0]);
+    expect(parsed.lastPollAt).toBe(state.lastPollAt);
+    expect(parsed.activeCount).toBe(1);
+    expect(Array.isArray(parsed.active)).toBe(true);
+    expect(parsed.active[0].prNumber).toBe(42);
   });
 });
 


### PR DESCRIPTION
Add --json flag to 'tps pulse status' command.

Files to modify (3 files, ~30 lines total):

1. packages/cli/src/commands/pulse.ts
   - Add 'json?: boolean' to PulseArgs interface (~line 570)
   - In printStatus() (~line 534), add parameter 'args: Pick<PulseArgs, "json"> = {}' and state param
   - After the 'active' filter, add: if (args.json) { console.log(JSON.stringify({ lastPollAt: state.lastPollAt, activeCount: active.length, active })); return; }
   - In runPulse() 'status' case (~line 592), pass { json: args.json } to printStatus()
   - Export printStatus so it's testable

2. packages/cli/bin/tps.ts
   - In the pulse command handler (~line 1005), add: json: Boolean(cli.flags.json)

3. packages/cli/test/pulse.test.ts
   - Import printStatus
   - Add test: create a state with one PR instance, call printStatus({ json: true }, state), capture console.log, verify JSON.parse works and has lastPollAt + activeCount + active array

Write code immediately. Do not explore beyond these three files.