### PR TITLE
fix: create branch from detached HEAD before autoCommit push

### DIFF
--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -530,6 +530,10 @@ export async function runAutoCommit(
   if (!hasWorkingTreeChanges && hasExistingCommits) {
     console.log(`[autoCommit] reusing existing commits on ${branchName}`);
     if (push) {
+      const checkoutResult = spawnSync(GIT_BIN, ["checkout", "-b", branchName], { cwd: repo, encoding: "utf-8" });
+      if (checkoutResult.status !== 0) {
+        spawnSync(GIT_BIN, ["checkout", branchName], { cwd: repo, encoding: "utf-8" });
+      }
       const pushResult = runSync(GIT_BIN, ["push", "-u", "origin", branchName], { cwd: repo, encoding: "utf-8" });
       const pushStdout = typeof pushResult.stdout === "string" ? pushResult.stdout.trim() : "";
       const pushStderr = typeof pushResult.stderr === "string" ? pushResult.stderr.trim() : "";


### PR DESCRIPTION
Fixes ops-106. When Codex commits on a detached HEAD, autoCommit tried to push a branch that didn't exist. Now creates the branch with `git checkout -b` before pushing. Fallback to `git checkout` if branch already exists.

+4 lines in codex-runtime.ts.