### PR TITLE
Truncate PR body in autoCommit — don't dump full task prompt.

### DIFF
--- a/packages/cli/src/utils/codex-runtime.ts
+++ b/packages/cli/src/utils/codex-runtime.ts
@@ -625,7 +625,7 @@ async function _runAutoCommitLegacy(
         prRepo: cfg.prRepo,
         ghAgent,
         prTitle: cfg.prTitle ?? taskSubject ?? `task: ${taskId}`,
-        prBody: taskBody,
+        prBody: taskBody ? taskBody.split('\n\n')[0].slice(0, 500) : undefined,
         reviewNotify: cfg.reviewNotify,
         mailDir: mailDir,
       },


### PR DESCRIPTION
Truncates PR body to first paragraph (max 500 chars) instead of dumping the full task prompt. One-line change in codex-runtime.ts line 628.