### PR TITLE
feat: add plugin slot registry and flair memory adapter

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -14,6 +14,7 @@ import { AgentRuntime, loadAgentConfig } from "@tpsdev-ai/agent";
 import yaml from "js-yaml";
 import { generateKeyPair, saveKeyPair, loadKeyPair } from "../utils/identity.js";
 import { createFlairClient } from "../utils/flair-client.js";
+import { loadPlugins } from "../plugins/index.js";
 import { createInterface as createPromptInterface } from "node:readline/promises";
 import { accessSync, constants, createReadStream, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, watch, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -750,6 +751,14 @@ export async function runAgent(args: AgentArgs): Promise<void> {
       }
 
       const config = loadAgentConfig(configPath);
+      if (config.flair) {
+        const flair = createFlairClient(
+          config.agentId,
+          config.flair.url ?? process.env.FLAIR_URL ?? "http://127.0.0.1:9926",
+          config.flair.keyPath ?? join(homedir(), ".tps", "identity", `${config.agentId}.key`),
+        );
+        loadPlugins({ slots: { memory: "flair" } }, { flair });
+      }
       const runtime = new AgentRuntime(config);
 
       if (args.action === "run") {

--- a/packages/cli/src/plugins/flair-memory.ts
+++ b/packages/cli/src/plugins/flair-memory.ts
@@ -1,0 +1,53 @@
+import type { FlairClient } from "../utils/flair-client.js";
+import { randomUUID } from "node:crypto";
+import type { MemoryProvider, MemoryResult, MemoryWriteInput, MemoryRecord } from "./registry.js";
+
+export class FlairMemoryProvider implements MemoryProvider {
+  constructor(private client: FlairClient) {}
+
+  async search(query: string, limit = 5): Promise<MemoryResult[]> {
+    const results = await this.client.search(query, limit);
+    return results.map((r) => ({
+      id: r.id,
+      text: r.content,
+      agentId: r.agentId,
+      similarity: r._score,
+      createdAt: undefined,
+    }));
+  }
+
+  async write(content: MemoryWriteInput): Promise<{ id: string }> {
+    const id = content.supersedes ?? `${content.agentId}-${randomUUID()}`;
+    await this.client.writeMemory(id, content.text, {
+      durability: content.durability,
+      type: content.type,
+      tags: content.tags,
+    });
+    return { id };
+  }
+
+  async read(id: string): Promise<MemoryRecord | null> {
+    const record = await this.client.getMemory(id);
+    if (!record) return null;
+    return {
+      id: record.id,
+      text: record.content,
+      agentId: record.agentId,
+      durability: record.durability,
+      tags: record.tags,
+      createdAt: record.createdAt,
+      type: record.type,
+      archived: record.archived,
+      updatedAt: record.updatedAt,
+    };
+  }
+
+  async bootstrap(opts?: { query?: string; maxTokens?: number }): Promise<string> {
+    void opts;
+    return this.client.bootstrap();
+  }
+
+  async ping(): Promise<boolean> {
+    return this.client.ping();
+  }
+}

--- a/packages/cli/src/plugins/index.ts
+++ b/packages/cli/src/plugins/index.ts
@@ -1,0 +1,4 @@
+export { getRegistry, registerSlot, getSlot, resetRegistry } from "./registry.js";
+export type { MemoryProvider, MemoryResult, MemoryWriteInput, MemoryRecord, SlotRegistry } from "./registry.js";
+export { FlairMemoryProvider } from "./flair-memory.js";
+export { loadPlugins } from "./loader.js";

--- a/packages/cli/src/plugins/loader.ts
+++ b/packages/cli/src/plugins/loader.ts
@@ -1,0 +1,16 @@
+import { registerSlot } from "./registry.js";
+import { FlairMemoryProvider } from "./flair-memory.js";
+import type { FlairClient } from "../utils/flair-client.js";
+
+export interface PluginConfig {
+  slots?: {
+    memory?: "flair";
+  };
+}
+
+export function loadPlugins(config: PluginConfig, deps: { flair?: FlairClient }): void {
+  const memorySlot = config.slots?.memory ?? "flair";
+  if (memorySlot === "flair" && deps.flair) {
+    registerSlot("memory", new FlairMemoryProvider(deps.flair));
+  }
+}

--- a/packages/cli/src/plugins/registry.ts
+++ b/packages/cli/src/plugins/registry.ts
@@ -1,0 +1,54 @@
+export interface MemoryProvider {
+  search(query: string, limit?: number): Promise<MemoryResult[]>;
+  write(content: MemoryWriteInput): Promise<{ id: string }>;
+  read(id: string): Promise<MemoryRecord | null>;
+  bootstrap(opts?: { query?: string; maxTokens?: number }): Promise<string>;
+  ping(): Promise<boolean>;
+}
+
+export interface MemoryResult {
+  id: string;
+  text: string;
+  agentId: string;
+  similarity?: number;
+  durability?: string;
+  tags?: string[];
+  createdAt?: string;
+}
+
+export interface MemoryWriteInput {
+  text: string;
+  agentId: string;
+  durability?: "permanent" | "persistent" | "standard" | "ephemeral";
+  type?: string;
+  tags?: string[];
+  supersedes?: string;
+}
+
+export interface MemoryRecord extends MemoryResult {
+  type?: string;
+  archived?: boolean;
+  updatedAt?: string;
+}
+
+export interface SlotRegistry {
+  memory: MemoryProvider | null;
+}
+
+let _registry: SlotRegistry = { memory: null };
+
+export function getRegistry(): SlotRegistry {
+  return _registry;
+}
+
+export function registerSlot<K extends keyof SlotRegistry>(slot: K, provider: SlotRegistry[K]): void {
+  _registry[slot] = provider;
+}
+
+export function getSlot<K extends keyof SlotRegistry>(slot: K): SlotRegistry[K] {
+  return _registry[slot];
+}
+
+export function resetRegistry(): void {
+  _registry = { memory: null };
+}

--- a/packages/cli/test/plugins/flair-memory.test.ts
+++ b/packages/cli/test/plugins/flair-memory.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, mock } from "bun:test";
+import { FlairMemoryProvider } from "../../src/plugins/flair-memory.js";
+
+function makeClient() {
+  return {
+    search: mock(async (_q: string, _limit = 5) => [{ id: "m1", content: "hello", agentId: "flint", _score: 0.9 }]),
+    writeMemory: mock(async (_id: string, _content: string, _opts: unknown) => {}),
+    getMemory: mock(async (id: string) => ({ id, content: "hello", agentId: "flint", durability: "standard", tags: ["a"] })),
+    bootstrap: mock(async () => "bootstrapped"),
+    ping: mock(async () => true),
+  };
+}
+
+describe("FlairMemoryProvider", () => {
+  it("delegates search/read/bootstrap/ping to FlairClient", async () => {
+    const client = makeClient();
+    const provider = new FlairMemoryProvider(client as any);
+
+    await expect(provider.search("hello", 3)).resolves.toEqual([{ id: "m1", text: "hello", agentId: "flint", similarity: 0.9, createdAt: undefined }]);
+    await expect(provider.read("m1")).resolves.toMatchObject({ id: "m1", text: "hello", agentId: "flint" });
+    await expect(provider.bootstrap()).resolves.toBe("bootstrapped");
+    await expect(provider.ping()).resolves.toBe(true);
+
+    expect(client.search).toHaveBeenCalledWith("hello", 3);
+    expect(client.getMemory).toHaveBeenCalledWith("m1");
+    expect(client.bootstrap).toHaveBeenCalled();
+    expect(client.ping).toHaveBeenCalled();
+  });
+
+  it("delegates writes to FlairClient.writeMemory", async () => {
+    const client = makeClient();
+    const provider = new FlairMemoryProvider(client as any);
+
+    const result = await provider.write({ text: "ship it", agentId: "anvil", durability: "persistent", type: "fact", tags: ["x"] });
+
+    expect(result.id).toBeString();
+    expect(client.writeMemory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/test/plugins/registry.test.ts
+++ b/packages/cli/test/plugins/registry.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { getSlot, registerSlot, resetRegistry } from "../../src/plugins/registry.js";
+import type { MemoryProvider } from "../../src/plugins/registry.js";
+
+const mockMemory: MemoryProvider = {
+  search: async () => [],
+  write: async () => ({ id: "test-1" }),
+  read: async () => null,
+  bootstrap: async () => "context",
+  ping: async () => true,
+};
+
+describe("SlotRegistry", () => {
+  beforeEach(() => resetRegistry());
+
+  it("starts with null slots", () => {
+    expect(getSlot("memory")).toBeNull();
+  });
+
+  it("registers and retrieves a provider", () => {
+    registerSlot("memory", mockMemory);
+    expect(getSlot("memory")).toBe(mockMemory);
+  });
+
+  it("replaces existing provider", () => {
+    registerSlot("memory", mockMemory);
+    const other: MemoryProvider = { ...mockMemory, ping: async () => false };
+    registerSlot("memory", other);
+    expect(getSlot("memory")).toBe(other);
+  });
+});


### PR DESCRIPTION
## Summary
- add a slot registry and plugin loader scaffold
- extract Flair memory integration into a first-class memory slot adapter
- minimally wire plugin loading during agent runtime startup

## Testing
- bun run build
- bun test packages/cli/test/plugins/