### PR TITLE
feat: add lifecycle hook registry and role config

### DIFF
--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -76,6 +76,8 @@ export function loadAgentConfig(path: string): AgentConfig {
       url: parsed.flair.url ? String(parsed.flair.url) : undefined,
       keyPath: parsed.flair.keyPath ? String(parsed.flair.keyPath) : undefined,
     } : undefined,
+    role: parsed.role ? String(parsed.role) as any : undefined,
+    roleConfig: parsed.roleConfig ? parsed.roleConfig as Record<string, unknown> : undefined,
     llm: {
       provider: parsed.llm?.provider || parsed.provider || "openai",
       model: parsed.llm?.model || parsed.model || "gpt-4o-mini",

--- a/packages/agent/src/runtime/types.ts
+++ b/packages/agent/src/runtime/types.ts
@@ -39,6 +39,10 @@ export interface AgentConfig {
   execAllowlist?: string[];
   /** Optional Flair memory/identity integration */
   flair?: FlairConfig;
+  /** Declarative runtime role */
+  role?: "reviewer" | "implementer" | "strategist" | "coordinator";
+  /** Role-specific config blob */
+  roleConfig?: Record<string, unknown>;
 }
 
 export interface ToolResult {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -14,7 +14,7 @@ import { AgentRuntime, loadAgentConfig } from "@tpsdev-ai/agent";
 import yaml from "js-yaml";
 import { generateKeyPair, saveKeyPair, loadKeyPair } from "../utils/identity.js";
 import { createFlairClient } from "../utils/flair-client.js";
-import { loadPlugins } from "../plugins/index.js";
+import { applyRole, loadPlugins } from "../plugins/index.js";
 import { createInterface as createPromptInterface } from "node:readline/promises";
 import { accessSync, constants, createReadStream, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, watch, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -758,6 +758,9 @@ export async function runAgent(args: AgentArgs): Promise<void> {
           config.flair.keyPath ?? join(homedir(), ".tps", "identity", `${config.agentId}.key`),
         );
         loadPlugins({ slots: { memory: "flair" } }, { flair });
+      }
+      if (config.role) {
+        applyRole({ role: config.role, ...(config.roleConfig ?? {}) }, config.agentId);
       }
       const runtime = new AgentRuntime(config);
 

--- a/packages/cli/src/plugins/hooks.ts
+++ b/packages/cli/src/plugins/hooks.ts
@@ -1,0 +1,45 @@
+export type HookName =
+  | "agent.boot"
+  | "agent.ready"
+  | "task.before"
+  | "task.after"
+  | "mail.received"
+  | "workspace.before_reset"
+  | "workspace.after_reset";
+
+export interface HookContext {
+  agentId: string;
+  [key: string]: unknown;
+}
+
+export interface HookRegistration<T extends HookContext = HookContext> {
+  name: string;
+  priority: number;
+  fn: (ctx: T) => Promise<unknown>;
+}
+
+const _hooks = new Map<HookName, HookRegistration[]>();
+
+export function registerHook(hook: HookName, registration: HookRegistration): void {
+  const list = _hooks.get(hook) ?? [];
+  list.push(registration);
+  list.sort((a, b) => a.priority - b.priority);
+  _hooks.set(hook, list);
+}
+
+export async function runHooks(hook: HookName, ctx: HookContext): Promise<unknown[]> {
+  const list = _hooks.get(hook) ?? [];
+  const results: unknown[] = [];
+  for (const reg of list) {
+    results.push(await reg.fn(ctx));
+  }
+  return results;
+}
+
+export function getHooks(hook: HookName): HookRegistration[] {
+  return _hooks.get(hook) ?? [];
+}
+
+export function resetHooks(): void {
+  _hooks.clear();
+}

--- a/packages/cli/src/plugins/index.ts
+++ b/packages/cli/src/plugins/index.ts
@@ -2,3 +2,7 @@ export { getRegistry, registerSlot, getSlot, resetRegistry } from "./registry.js
 export type { MemoryProvider, MemoryResult, MemoryWriteInput, MemoryRecord, SlotRegistry } from "./registry.js";
 export { FlairMemoryProvider } from "./flair-memory.js";
 export { loadPlugins } from "./loader.js";
+export { registerHook, runHooks, getHooks, resetHooks } from "./hooks.js";
+export type { HookName, HookContext, HookRegistration } from "./hooks.js";
+export { applyRole } from "./roles.js";
+export type { RoleConfig } from "./roles.js";

--- a/packages/cli/src/plugins/roles.ts
+++ b/packages/cli/src/plugins/roles.ts
@@ -1,0 +1,38 @@
+import { registerHook } from "./hooks.js";
+
+export interface RoleConfig {
+  role: string;
+  reviewStyle?: "security" | "architecture" | "general";
+  reviewRules?: string[];
+  ackAfterReview?: boolean;
+  autoAssign?: boolean;
+}
+
+export function applyRole(config: RoleConfig, agentId: string): void {
+  switch (config.role) {
+    case "reviewer": {
+      registerHook("mail.received", {
+        name: `${agentId}-review-filter`,
+        priority: 10,
+        fn: async (_ctx) => {
+          return { filtered: false };
+        },
+      });
+      break;
+    }
+    case "implementer": {
+      registerHook("task.after", {
+        name: `${agentId}-task-cleanup`,
+        priority: 90,
+        fn: async (_ctx) => {
+          return {};
+        },
+      });
+      break;
+    }
+    case "strategist":
+    case "coordinator":
+    default:
+      break;
+  }
+}

--- a/packages/cli/test/plugins/hooks.test.ts
+++ b/packages/cli/test/plugins/hooks.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { getHooks, registerHook, resetHooks, runHooks } from "../../src/plugins/hooks.js";
+
+describe("HookRegistry", () => {
+  beforeEach(() => resetHooks());
+
+  it("runs hooks in priority order", async () => {
+    const order: string[] = [];
+
+    registerHook("agent.boot", {
+      name: "second",
+      priority: 20,
+      fn: async () => {
+        order.push("second");
+      },
+    });
+
+    registerHook("agent.boot", {
+      name: "first",
+      priority: 10,
+      fn: async () => {
+        order.push("first");
+      },
+    });
+
+    await runHooks("agent.boot", { agentId: "test" });
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  it("returns results from each hook", async () => {
+    registerHook("task.before", {
+      name: "inject",
+      priority: 10,
+      fn: async () => ({ prepend: "context" }),
+    });
+
+    const results = await runHooks("task.before", { agentId: "test" });
+    expect(results).toEqual([{ prepend: "context" }]);
+  });
+
+  it("runs empty hook list without error", async () => {
+    const results = await runHooks("agent.ready", { agentId: "test" });
+    expect(results).toEqual([]);
+    expect(getHooks("agent.ready")).toEqual([]);
+  });
+});

--- a/packages/cli/test/plugins/roles.test.ts
+++ b/packages/cli/test/plugins/roles.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { getHooks, resetHooks } from "../../src/plugins/hooks.js";
+import { applyRole } from "../../src/plugins/roles.js";
+
+describe("applyRole", () => {
+  beforeEach(() => resetHooks());
+
+  it("registers review filter hook for reviewer role", () => {
+    applyRole({ role: "reviewer" }, "sherlock");
+    expect(getHooks("mail.received").length).toBe(1);
+    expect(getHooks("mail.received")[0]?.name).toBe("sherlock-review-filter");
+  });
+
+  it("registers task cleanup hook for implementer role", () => {
+    applyRole({ role: "implementer" }, "ember");
+    expect(getHooks("task.after").length).toBe(1);
+  });
+
+  it("no hooks for strategist role", () => {
+    applyRole({ role: "strategist" }, "flint");
+    expect(getHooks("mail.received").length).toBe(0);
+    expect(getHooks("task.after").length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add lifecycle hook registry and role application scaffolding
- extend agent config with declarative role and roleConfig fields
- wire role application into agent startup after plugin loading

## Testing
- bun run build
- bun test packages/cli/test/plugins/