### PR TITLE
feat: branch supervisor scripts for persistent connectivity (ops-115)

### DIFF
--- a/scripts/branch-supervisor.sh
+++ b/scripts/branch-supervisor.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# branch-supervisor.sh — restart loop for tps branch daemon
+# Writes supervisor PID to ~/.tps/branch-supervisor.pid
+# Logs to ~/.tps/branch-supervisor.log
+# Respects SIGTERM for clean shutdown
+
+set -euo pipefail
+
+TPS_ROOT="${TPS_ROOT:-$HOME/.tps}"
+SUPERVISOR_PID_FILE="$TPS_ROOT/branch-supervisor.pid"
+SUPERVISOR_LOG="$TPS_ROOT/branch-supervisor.log"
+BRANCH_PID_FILE="$TPS_ROOT/branch.pid"
+BACKOFF=5
+
+# Resolve tps CLI — prefer dist binary, fall back to bun dev
+if [ -f "$HOME/src/tpsdev-ai/cli/packages/cli/dist/bin/tps.js" ]; then
+  TPS_BIN="$HOME/.bun/bin/bun"
+  TPS_SCRIPT="$HOME/src/tpsdev-ai/cli/packages/cli/dist/bin/tps.js"
+elif command -v tps &>/dev/null; then
+  TPS_BIN="tps"
+  TPS_SCRIPT=""
+else
+  echo "ERROR: tps not found" >&2
+  exit 1
+fi
+
+run_branch() {
+  if [ -n "$TPS_SCRIPT" ]; then
+    TPS_BRANCH_DAEMON=1 "$TPS_BIN" "$TPS_SCRIPT" branch start
+  else
+    TPS_BRANCH_DAEMON=1 "$TPS_BIN" branch start
+  fi
+}
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "$SUPERVISOR_LOG"
+}
+
+cleanup() {
+  log "Supervisor received SIGTERM — shutting down"
+  # Stop branch daemon if running
+  if [ -f "$BRANCH_PID_FILE" ]; then
+    local pid
+    pid=$(cat "$BRANCH_PID_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      log "Stopping branch daemon (pid $pid)"
+      kill -TERM "$pid" 2>/dev/null || true
+      # Wait up to 5s for clean exit
+      for _ in 1 2 3 4 5; do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 1
+      done
+    fi
+  fi
+  rm -f "$SUPERVISOR_PID_FILE"
+  log "Supervisor exited cleanly"
+  exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+mkdir -p "$TPS_ROOT"
+
+# Write supervisor PID
+echo $$ > "$SUPERVISOR_PID_FILE"
+log "Branch supervisor started (pid $$)"
+
+while true; do
+  log "Starting branch daemon (TPS_BRANCH_DAEMON=1)..."
+
+  # Run branch in foreground (TPS_BRANCH_DAEMON=1 skips the fork)
+  run_branch &
+  BRANCH_PID=$!
+
+  # Wait for it to exit (or supervisor to be signaled)
+  wait $BRANCH_PID 2>/dev/null
+  EXIT_CODE=$?
+
+  # Exit code 0 means intentional stop (e.g. tps branch stop sent SIGTERM)
+  if [ $EXIT_CODE -eq 0 ]; then
+    log "Branch daemon exited cleanly (code 0) — not restarting"
+    break
+  fi
+
+  log "Branch daemon exited (code $EXIT_CODE) — restarting in ${BACKOFF}s"
+  sleep "$BACKOFF" &
+  wait $! 2>/dev/null || true
+done
+
+rm -f "$SUPERVISOR_PID_FILE"
+log "Supervisor exiting"

--- a/scripts/setup-branch-service.sh
+++ b/scripts/setup-branch-service.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# setup-branch-service.sh — install and start the branch supervisor
+# Idempotent: safe to run multiple times
+# Works on exe.dev containers (no systemd --user required)
+
+set -euo pipefail
+
+TPS_ROOT="${TPS_ROOT:-$HOME/.tps}"
+SUPERVISOR_PID_FILE="$TPS_ROOT/branch-supervisor.pid"
+SUPERVISOR_LOG="$TPS_ROOT/branch-supervisor.log"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUPERVISOR_SCRIPT="$SCRIPT_DIR/branch-supervisor.sh"
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] setup-branch-service: $*"
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# Verify supervisor script exists
+[ -f "$SUPERVISOR_SCRIPT" ] || die "branch-supervisor.sh not found at $SUPERVISOR_SCRIPT"
+
+# Make it executable
+chmod +x "$SUPERVISOR_SCRIPT"
+log "Supervisor script: $SUPERVISOR_SCRIPT"
+
+# Create TPS root if needed
+mkdir -p "$TPS_ROOT"
+
+# Check if supervisor already running
+if [ -f "$SUPERVISOR_PID_FILE" ]; then
+  existing_pid=$(cat "$SUPERVISOR_PID_FILE" 2>/dev/null || true)
+  if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+    log "Supervisor already running (pid $existing_pid) — nothing to do"
+    exit 0
+  else
+    log "Stale supervisor PID file found — cleaning up"
+    rm -f "$SUPERVISOR_PID_FILE"
+  fi
+fi
+
+# Start supervisor in background, detached from terminal
+log "Starting branch supervisor..."
+nohup "$SUPERVISOR_SCRIPT" >> "$SUPERVISOR_LOG" 2>&1 &
+SUPERVISOR_PID=$!
+
+# Give it a moment to write its PID file
+sleep 1
+
+# Verify it started
+if kill -0 "$SUPERVISOR_PID" 2>/dev/null; then
+  log "Branch supervisor started (pid $SUPERVISOR_PID)"
+  log "Log: $SUPERVISOR_LOG"
+  log "PID file: $SUPERVISOR_PID_FILE"
+else
+  die "Supervisor failed to start — check $SUPERVISOR_LOG"
+fi


### PR DESCRIPTION
## Summary

Adds two scripts to make the branch daemon self-healing on VM agents (Phase 1 of ops-115).

## Changes

### `scripts/branch-supervisor.sh`
- Restart loop: runs `tps branch start` in foreground mode (`TPS_BRANCH_DAEMON=1`) so exit codes are meaningful
- 5s backoff between restarts to avoid tight loops
- SIGTERM handler: cleanly stops the branch daemon and removes PID file before exiting
- Logs timestamped events to `~/.tps/branch-supervisor.log`
- Writes own PID to `~/.tps/branch-supervisor.pid`
- Clean exit (code 0) from branch daemon stops the loop — respects intentional `tps branch stop`
- Auto-discovers tps binary (dist build or bun dev)

### `scripts/setup-branch-service.sh`
- Idempotent: safe to run multiple times — detects running supervisor and exits early
- Starts supervisor via `nohup` detached from terminal
- Works on exe.dev containers (no systemd --user required)
- Verifies supervisor starts successfully before exiting

## Test
- `bun test` passes with same 3 pre-existing failures on main (unrelated to these scripts)
- Both scripts pass `bash -n` syntax check

Closes #234