### PR TITLE
fix: use setsid to detach supervisor from branch child process group

### DIFF
--- a/scripts/branch-supervisor.sh
+++ b/scripts/branch-supervisor.sh
@@ -73,8 +73,11 @@ while true; do
   BRANCH_PID=$!
 
   # Wait for it to exit (or supervisor to be signaled)
+  # Use set +e so SIGKILL exit doesn't abort the script
+  set +e
   wait $BRANCH_PID 2>/dev/null
   EXIT_CODE=$?
+  set -e
 
   # Exit code 0 means intentional stop (e.g. tps branch stop sent SIGTERM)
   if [ $EXIT_CODE -eq 0 ]; then

--- a/scripts/setup-branch-service.sh
+++ b/scripts/setup-branch-service.sh
@@ -42,9 +42,10 @@ if [ -f "$SUPERVISOR_PID_FILE" ]; then
   fi
 fi
 
-# Start supervisor in background, detached from terminal
+# Start supervisor in a new session (setsid) so SIGKILL to the branch child
+# does not propagate up to the supervisor process group.
 log "Starting branch supervisor..."
-nohup "$SUPERVISOR_SCRIPT" >> "$SUPERVISOR_LOG" 2>&1 &
+setsid nohup "$SUPERVISOR_SCRIPT" >> "$SUPERVISOR_LOG" 2>&1 &
 SUPERVISOR_PID=$!
 
 # Give it a moment to write its PID file


### PR DESCRIPTION
## Problem

After #235 merged, live testing showed SIGKILL to the branch daemon was killing the supervisor too. Root cause: `nohup ... &` doesn't fully detach from the process group — SIGKILL propagated up.

## Fix

- `setup-branch-service.sh`: launch supervisor with `setsid` so it runs in a new session, isolated from the branch daemon's process group
- `branch-supervisor.sh`: wrap `wait` with `set +e`/`set -e` so non-zero exit codes (e.g. 137 from SIGKILL) don't abort the script

## Tested



Branch restarts within 5s. Supervisor survives. ✅