### PR TITLE
feat: Global Address List for agent mail routing (ops-119)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -22,6 +22,7 @@ const cli = meow(
     heartbeat <agent-id> [--nonono] Send a heartbeat/ping for an agent
     context <action>  Workstream context memory (read/update/list)
     mail <action>     Mailroom operations (send/check/list/search)
+    gal <action>      Global Address List (list/set/remove/sync)
     auth <action>     OAuth provider authentication (login/status/revoke/refresh)
     agent run|start|health  Manage tps-agent runtime from config
     identity <action> Key management (init/show/register/list/revoke/verify)
@@ -765,6 +766,25 @@ async function main() {
       });
       break;
     }
+    case "gal": {
+      const action = rest[0] as "list" | "set" | "remove" | "sync" | undefined;
+      const valid = ["list", "set", "remove", "sync"];
+      if (cli.flags.help || !action || !valid.includes(action)) {
+        console.log(
+          "Usage:\n  tps gal list                      List all GAL entries\n  tps gal set <agentId> <branchId>  Map agent name → branch ID\n  tps gal remove <agentId>          Remove a GAL entry\n  tps gal sync                      Seed GAL from branch-office registrations"
+        );
+        process.exit(cli.flags.help ? 0 : 1);
+      }
+      const { runGal } = await import("../src/commands/gal.js");
+      runGal({
+        action,
+        agentId: rest[1],
+        branchId: rest[2],
+        json: !!cli.flags.json,
+      });
+      break;
+    }
+
     case "branch": {
       const action = rest[0] as "init" | "start" | "stop" | "status" | "log" | undefined;
       const valid = ["init", "start", "stop", "status", "log"];

--- a/packages/cli/src/commands/gal.ts
+++ b/packages/cli/src/commands/gal.ts
@@ -1,0 +1,102 @@
+/**
+ * gal.ts — Global Address List CLI commands
+ *
+ * tps gal list                      List all entries
+ * tps gal set <agentId> <branchId>  Map agent → branch
+ * tps gal remove <agentId>          Remove entry
+ * tps gal sync                      Seed from branch-office registrations
+ */
+import { galList, galLookup, galRemove, galSet, galSync } from "../utils/gal.js";
+
+export interface GalArgs {
+  action: "list" | "set" | "remove" | "sync";
+  agentId?: string;
+  branchId?: string;
+  json?: boolean;
+}
+
+export function runGal(args: GalArgs): void {
+  switch (args.action) {
+    case "list": {
+      const entries = galList();
+      if (args.json) {
+        console.log(JSON.stringify(entries, null, 2));
+        return;
+      }
+      if (entries.length === 0) {
+        console.log("GAL is empty. Use `tps gal set <agentId> <branchId>` to add entries.");
+        return;
+      }
+      const maxAgent = Math.max(8, ...entries.map(e => e.agentId.length));
+      const maxBranch = Math.max(8, ...entries.map(e => e.branchId.length));
+      console.log(`${"AGENT".padEnd(maxAgent)}  ${"BRANCH".padEnd(maxBranch)}  UPDATED`);
+      console.log(`${"-".repeat(maxAgent)}  ${"-".repeat(maxBranch)}  ${"-------------------"}`);
+      for (const e of entries) {
+        console.log(`${e.agentId.padEnd(maxAgent)}  ${e.branchId.padEnd(maxBranch)}  ${e.updatedAt.slice(0, 19)}`);
+      }
+      return;
+    }
+
+    case "set": {
+      if (!args.agentId || !args.branchId) {
+        console.error("Usage: tps gal set <agentId> <branchId>");
+        process.exit(1);
+      }
+      if (!/^[a-zA-Z0-9_-]+$/.test(args.agentId)) {
+        console.error(`Invalid agentId: ${args.agentId} (alphanumeric, _ and - only)`);
+        process.exit(1);
+      }
+      if (!/^[a-zA-Z0-9_-]+$/.test(args.branchId)) {
+        console.error(`Invalid branchId: ${args.branchId} (alphanumeric, _ and - only)`);
+        process.exit(1);
+      }
+      const entry = galSet(args.agentId, args.branchId);
+      if (args.json) {
+        console.log(JSON.stringify(entry, null, 2));
+      } else {
+        console.log(`GAL: ${args.agentId} → ${args.branchId}`);
+      }
+      return;
+    }
+
+    case "remove": {
+      if (!args.agentId) {
+        console.error("Usage: tps gal remove <agentId>");
+        process.exit(1);
+      }
+      const removed = galRemove(args.agentId);
+      if (args.json) {
+        console.log(JSON.stringify({ removed, agentId: args.agentId }));
+      } else if (removed) {
+        console.log(`Removed GAL entry: ${args.agentId}`);
+      } else {
+        console.log(`No GAL entry found for: ${args.agentId}`);
+        process.exit(1);
+      }
+      return;
+    }
+
+    case "sync": {
+      const result = galSync();
+      if (args.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        if (result.added.length > 0) {
+          console.log(`Added: ${result.added.join(", ")}`);
+        }
+        if (result.skipped.length > 0) {
+          console.log(`Skipped (already present): ${result.skipped.join(", ")}`);
+        }
+        if (result.added.length === 0 && result.skipped.length === 0) {
+          console.log("No branch-office entries found to sync.");
+        }
+      }
+      return;
+    }
+
+    default: {
+      console.error("Unknown gal action. Use: list, set, remove, sync");
+      process.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -7,6 +7,7 @@ import { homedir } from "node:os";
 import { existsSync, readdirSync, readFileSync, renameSync, statSync, watch } from "node:fs";
 import { loadHostIdentityId } from "../utils/identity.js";
 import { queueOutboxMessage } from "../utils/outbox.js";
+import { galLookup } from "../utils/gal.js";
 
 interface MailArgs {
   action: "send" | "check" | "list" | "stats" | "log" | "read" | "watch" | "search" | "relay" | "topic" | "subscribe" | "unsubscribe" | "publish" | "ack" | "nack" | "gc";
@@ -106,30 +107,35 @@ export async function runMail(args: MailArgs): Promise<void> {
         return;
       }
 
+      // GAL lookup: resolve agent name → physical branch ID
+      const galBranchId = galLookup(to);
+      const effectiveTo = galBranchId ?? to;
+
       // Check for remote branch (has remote.json)
       const remoteJsonPath = join(
         process.env.HOME || homedir(),
         ".tps",
         "branch-office",
-        to,
+        effectiveTo,
         "remote.json"
       );
       if (existsSync(remoteJsonPath)) {
         assertValidBody(args.message);
-        await deliverToRemoteBranch(to, { to, from, body: args.message });
+        await deliverToRemoteBranch(effectiveTo, { to, from, body: args.message });
         if (args.json) {
-          console.log(JSON.stringify({ status: "sent", to, transport: "remote" }));
+          console.log(JSON.stringify({ status: "sent", to, transport: "remote", resolvedBranch: effectiveTo }));
         } else {
-          console.log(`Mail delivered to remote branch '${to}'.`);
+          const resolvedNote = galBranchId ? ` (via GAL: ${galBranchId})` : "";
+          console.log(`Mail delivered to remote branch '${to}'${resolvedNote}.`);
         }
         return;
       }
 
       // Inbound Bridge: check if recipient is a local branch office agent
-      const branchInbox = join(process.env.HOME || homedir(), ".tps", "branch-office", to, "mail", "inbox");
+      const branchInbox = join(process.env.HOME || homedir(), ".tps", "branch-office", effectiveTo, "mail", "inbox");
       if (existsSync(branchInbox)) {
         assertValidBody(args.message);
-        deliverToSandbox(to, {
+        deliverToSandbox(effectiveTo, {
           to,
           from,
           body: args.message,

--- a/packages/cli/src/utils/gal.ts
+++ b/packages/cli/src/utils/gal.ts
@@ -1,0 +1,123 @@
+/**
+ * gal.ts — Global Address List
+ *
+ * Maps agent names (e.g. "flint") to their physical branch IDs (e.g. "tps-rockit").
+ * Stored at ~/.tps/gal.json. Simple JSON file, no external deps.
+ */
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface GalEntry {
+  agentId: string;     // logical name (e.g. "flint")
+  branchId: string;    // physical branch ID (e.g. "tps-rockit")
+  updatedAt: string;   // ISO timestamp
+}
+
+export interface GalFile {
+  version: 1;
+  entries: GalEntry[];
+}
+
+function tpsRoot(): string {
+  return process.env.TPS_ROOT || join(process.env.HOME || homedir(), ".tps");
+}
+
+export function galPath(): string {
+  return join(tpsRoot(), "gal.json");
+}
+
+function loadGal(): GalFile {
+  const p = galPath();
+  if (!existsSync(p)) return { version: 1, entries: [] };
+  try {
+    const raw = JSON.parse(readFileSync(p, "utf-8"));
+    if (raw?.version === 1 && Array.isArray(raw.entries)) return raw as GalFile;
+  } catch { /* fall through */ }
+  return { version: 1, entries: [] };
+}
+
+function saveGal(gal: GalFile): void {
+  mkdirSync(tpsRoot(), { recursive: true });
+  writeFileSync(galPath(), JSON.stringify(gal, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Look up the branch ID for a given agent name.
+ * Returns null if not found.
+ */
+export function galLookup(agentId: string): string | null {
+  const gal = loadGal();
+  const entry = gal.entries.find(e => e.agentId === agentId);
+  return entry?.branchId ?? null;
+}
+
+/**
+ * List all GAL entries.
+ */
+export function galList(): GalEntry[] {
+  return loadGal().entries;
+}
+
+/**
+ * Add or update a GAL entry.
+ */
+export function galSet(agentId: string, branchId: string): GalEntry {
+  const gal = loadGal();
+  const idx = gal.entries.findIndex(e => e.agentId === agentId);
+  const entry: GalEntry = { agentId, branchId, updatedAt: new Date().toISOString() };
+  if (idx >= 0) {
+    gal.entries[idx] = entry;
+  } else {
+    gal.entries.push(entry);
+  }
+  saveGal(gal);
+  return entry;
+}
+
+/**
+ * Remove a GAL entry by agent ID.
+ * Returns true if removed, false if not found.
+ */
+export function galRemove(agentId: string): boolean {
+  const gal = loadGal();
+  const before = gal.entries.length;
+  gal.entries = gal.entries.filter(e => e.agentId !== agentId);
+  if (gal.entries.length === before) return false;
+  saveGal(gal);
+  return true;
+}
+
+/**
+ * Seed the GAL from existing branch-office registrations.
+ * Reads ~/.tps/branch-office/ dirs that have a remote.json and registers them.
+ * Uses the directory name as both agentId and branchId (can be updated manually).
+ * Does not overwrite existing entries.
+ */
+export function galSync(): { added: string[]; skipped: string[] } {
+  const branchDir = join(tpsRoot(), "branch-office");
+  if (!existsSync(branchDir)) return { added: [], skipped: [] };
+
+  const added: string[] = [];
+  const skipped: string[] = [];
+
+  let dirs: string[];
+  try {
+    dirs = readdirSync(branchDir);
+  } catch {
+    return { added: [], skipped: [] };
+  }
+
+  for (const branchId of dirs) {
+    const remoteJsonPath = join(branchDir, branchId, "remote.json");
+    if (!existsSync(remoteJsonPath)) continue;
+    if (galLookup(branchId) !== null) {
+      skipped.push(branchId);
+      continue;
+    }
+    galSet(branchId, branchId);
+    added.push(branchId);
+  }
+
+  return { added, skipped };
+}

--- a/packages/cli/src/utils/gal.ts
+++ b/packages/cli/src/utils/gal.ts
@@ -122,24 +122,17 @@ export function galSync(): { added: string[]; skipped: string[] } {
     const remoteJsonPath = join(branchDir, branchId, "remote.json");
     if (!existsSync(remoteJsonPath)) continue;
 
-    // Heuristic: strip "tps-" prefix to derive the logical agent name
-    // e.g. "tps-rockit" → "rockit", "tps-anvil" → "anvil"
-    // The branchId entry is always added; the stripped name is added as an alias if different.
-    const agentAlias = branchId.startsWith("tps-") ? branchId.slice(4) : branchId;
+    // Derive logical agent name: strip "tps-" prefix if present.
+    // e.g. "tps-rockit" → agentId="rockit", branchId="tps-rockit"
+    //      "ember"      → agentId="ember",   branchId="ember"
+    const agentId = branchId.startsWith("tps-") ? branchId.slice(4) : branchId;
 
-    // Add mapping for the branch ID itself (idempotent)
-    if (galLookup(branchId) !== null) {
-      skipped.push(branchId);
-    } else {
-      galSet(branchId, branchId);
-      added.push(branchId);
+    if (galLookup(agentId) !== null) {
+      skipped.push(agentId);
+      continue;
     }
-
-    // Add alias mapping (agentAlias → branchId) if different and not already present
-    if (agentAlias !== branchId && galLookup(agentAlias) === null) {
-      galSet(agentAlias, branchId);
-      added.push(agentAlias);
-    }
+    galSet(agentId, branchId);
+    added.push(agentId);
   }
 
   return { added, skipped };

--- a/packages/cli/src/utils/gal.ts
+++ b/packages/cli/src/utils/gal.ts
@@ -4,9 +4,10 @@
  * Maps agent names (e.g. "flint") to their physical branch IDs (e.g. "tps-rockit").
  * Stored at ~/.tps/gal.json. Simple JSON file, no external deps.
  */
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
 
 export interface GalEntry {
   agentId: string;     // logical name (e.g. "flint")
@@ -38,8 +39,17 @@ function loadGal(): GalFile {
 }
 
 function saveGal(gal: GalFile): void {
-  mkdirSync(tpsRoot(), { recursive: true });
-  writeFileSync(galPath(), JSON.stringify(gal, null, 2) + "\n", "utf-8");
+  const root = tpsRoot();
+  mkdirSync(root, { recursive: true });
+  // Atomic write: tmp file in same dir + rename
+  const tmp = join(root, `.gal-${randomUUID()}.tmp`);
+  try {
+    writeFileSync(tmp, JSON.stringify(gal, null, 2) + "\n", "utf-8");
+    renameSync(tmp, galPath());
+  } catch (err) {
+    try { writeFileSync(galPath(), "", "utf-8"); } catch {} // cleanup attempt
+    throw err;
+  }
 }
 
 /**
@@ -111,12 +121,25 @@ export function galSync(): { added: string[]; skipped: string[] } {
   for (const branchId of dirs) {
     const remoteJsonPath = join(branchDir, branchId, "remote.json");
     if (!existsSync(remoteJsonPath)) continue;
+
+    // Heuristic: strip "tps-" prefix to derive the logical agent name
+    // e.g. "tps-rockit" → "rockit", "tps-anvil" → "anvil"
+    // The branchId entry is always added; the stripped name is added as an alias if different.
+    const agentAlias = branchId.startsWith("tps-") ? branchId.slice(4) : branchId;
+
+    // Add mapping for the branch ID itself (idempotent)
     if (galLookup(branchId) !== null) {
       skipped.push(branchId);
-      continue;
+    } else {
+      galSet(branchId, branchId);
+      added.push(branchId);
     }
-    galSet(branchId, branchId);
-    added.push(branchId);
+
+    // Add alias mapping (agentAlias → branchId) if different and not already present
+    if (agentAlias !== branchId && galLookup(agentAlias) === null) {
+      galSet(agentAlias, branchId);
+      added.push(agentAlias);
+    }
   }
 
   return { added, skipped };

--- a/packages/cli/test/gal.test.ts
+++ b/packages/cli/test/gal.test.ts
@@ -87,8 +87,7 @@ describe("GAL utilities", () => {
   });
 
   it("galSync seeds from branch-office dirs with remote.json", async () => {
-    const { galSync, galList } = await getGal();
-    // Set up fake branch-office dirs
+    const { galSync, galList, galLookup } = await getGal();
     const branchDir = join(testRoot, "branch-office");
     mkdirSync(join(branchDir, "tps-rockit"), { recursive: true });
     writeFileSync(join(branchDir, "tps-rockit", "remote.json"), JSON.stringify({ host: "rockit" }));
@@ -96,31 +95,39 @@ describe("GAL utilities", () => {
     writeFileSync(join(branchDir, "tps-ember", "remote.json"), JSON.stringify({ host: "ember" }));
     // Dir without remote.json should be ignored
     mkdirSync(join(branchDir, "no-remote"), { recursive: true });
+    // Non-prefixed dir: agentId = branchId
+    mkdirSync(join(branchDir, "standalone"), { recursive: true });
+    writeFileSync(join(branchDir, "standalone", "remote.json"), JSON.stringify({}));
 
     const result = galSync();
-    // Each tps-prefixed dir adds branchId + alias (e.g. "tps-rockit" + "rockit")
-    expect(result.added).toContain("tps-rockit");
+    // tps-prefixed: agentId is stripped name, branchId is full name
     expect(result.added).toContain("rockit");
-    expect(result.added).toContain("tps-ember");
     expect(result.added).toContain("ember");
+    // non-prefixed: agentId = branchId
+    expect(result.added).toContain("standalone");
     expect(result.skipped).toHaveLength(0);
 
+    // Verify mappings
+    expect(galLookup("rockit")).toBe("tps-rockit");
+    expect(galLookup("ember")).toBe("tps-ember");
+    expect(galLookup("standalone")).toBe("standalone");
+
     const entries = galList();
-    expect(entries).toHaveLength(4); // tps-rockit, rockit, tps-ember, ember
+    expect(entries).toHaveLength(3);
   });
 
   it("galSync skips already-present entries", async () => {
     const { galSet, galSync } = await getGal();
-    galSet("tps-rockit", "tps-rockit");
+    // Pre-populate with the stripped agent name
+    galSet("rockit", "tps-rockit");
 
     const branchDir = join(testRoot, "branch-office");
     mkdirSync(join(branchDir, "tps-rockit"), { recursive: true });
     writeFileSync(join(branchDir, "tps-rockit", "remote.json"), JSON.stringify({}));
 
     const result = galSync();
-    expect(result.skipped).toContain("tps-rockit");
-    // The alias "rockit" is still new
-    expect(result.added).toContain("rockit");
+    expect(result.added).toHaveLength(0);
+    expect(result.skipped).toContain("rockit");
   });
 
   it("galSync returns empty result when branch-office dir missing", async () => {

--- a/packages/cli/test/gal.test.ts
+++ b/packages/cli/test/gal.test.ts
@@ -98,12 +98,15 @@ describe("GAL utilities", () => {
     mkdirSync(join(branchDir, "no-remote"), { recursive: true });
 
     const result = galSync();
+    // Each tps-prefixed dir adds branchId + alias (e.g. "tps-rockit" + "rockit")
     expect(result.added).toContain("tps-rockit");
+    expect(result.added).toContain("rockit");
     expect(result.added).toContain("tps-ember");
+    expect(result.added).toContain("ember");
     expect(result.skipped).toHaveLength(0);
 
     const entries = galList();
-    expect(entries).toHaveLength(2);
+    expect(entries).toHaveLength(4); // tps-rockit, rockit, tps-ember, ember
   });
 
   it("galSync skips already-present entries", async () => {
@@ -115,8 +118,9 @@ describe("GAL utilities", () => {
     writeFileSync(join(branchDir, "tps-rockit", "remote.json"), JSON.stringify({}));
 
     const result = galSync();
-    expect(result.added).toHaveLength(0);
     expect(result.skipped).toContain("tps-rockit");
+    // The alias "rockit" is still new
+    expect(result.added).toContain("rockit");
   });
 
   it("galSync returns empty result when branch-office dir missing", async () => {

--- a/packages/cli/test/gal.test.ts
+++ b/packages/cli/test/gal.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Override TPS_ROOT to an isolated temp dir for each test
+let testRoot: string;
+
+function withTestRoot<T>(fn: () => T): T {
+  const orig = process.env.TPS_ROOT;
+  process.env.TPS_ROOT = testRoot;
+  try {
+    return fn();
+  } finally {
+    if (orig === undefined) delete process.env.TPS_ROOT;
+    else process.env.TPS_ROOT = orig;
+  }
+}
+
+// Re-import gal functions using TPS_ROOT override
+// We import inline so the module uses the current env
+async function getGal() {
+  // Clear bun module cache by using a fresh dynamic import each time
+  return await import("../src/utils/gal.js");
+}
+
+describe("GAL utilities", () => {
+  beforeEach(() => {
+    testRoot = join(tmpdir(), `tps-gal-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testRoot, { recursive: true });
+    process.env.TPS_ROOT = testRoot;
+  });
+
+  afterEach(() => {
+    delete process.env.TPS_ROOT;
+    try { rmSync(testRoot, { recursive: true, force: true }); } catch {}
+  });
+
+  it("returns empty list when no gal.json exists", async () => {
+    const { galList } = await getGal();
+    expect(galList()).toEqual([]);
+  });
+
+  it("galSet adds a new entry", async () => {
+    const { galSet, galList, galLookup } = await getGal();
+    const entry = galSet("flint", "tps-rockit");
+    expect(entry.agentId).toBe("flint");
+    expect(entry.branchId).toBe("tps-rockit");
+    expect(entry.updatedAt).toBeString();
+
+    const entries = galList();
+    expect(entries).toHaveLength(1);
+    expect(galLookup("flint")).toBe("tps-rockit");
+  });
+
+  it("galSet updates an existing entry", async () => {
+    const { galSet, galList } = await getGal();
+    galSet("flint", "tps-rockit");
+    galSet("flint", "tps-rockit-2");
+
+    const entries = galList();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.branchId).toBe("tps-rockit-2");
+  });
+
+  it("galLookup returns null for unknown agent", async () => {
+    const { galLookup } = await getGal();
+    expect(galLookup("unknown-agent")).toBeNull();
+  });
+
+  it("galRemove removes an existing entry", async () => {
+    const { galSet, galRemove, galList } = await getGal();
+    galSet("flint", "tps-rockit");
+    galSet("kern", "tps-rockit");
+
+    const removed = galRemove("flint");
+    expect(removed).toBe(true);
+
+    const entries = galList();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.agentId).toBe("kern");
+  });
+
+  it("galRemove returns false for unknown entry", async () => {
+    const { galRemove } = await getGal();
+    expect(galRemove("nobody")).toBe(false);
+  });
+
+  it("galSync seeds from branch-office dirs with remote.json", async () => {
+    const { galSync, galList } = await getGal();
+    // Set up fake branch-office dirs
+    const branchDir = join(testRoot, "branch-office");
+    mkdirSync(join(branchDir, "tps-rockit"), { recursive: true });
+    writeFileSync(join(branchDir, "tps-rockit", "remote.json"), JSON.stringify({ host: "rockit" }));
+    mkdirSync(join(branchDir, "tps-ember"), { recursive: true });
+    writeFileSync(join(branchDir, "tps-ember", "remote.json"), JSON.stringify({ host: "ember" }));
+    // Dir without remote.json should be ignored
+    mkdirSync(join(branchDir, "no-remote"), { recursive: true });
+
+    const result = galSync();
+    expect(result.added).toContain("tps-rockit");
+    expect(result.added).toContain("tps-ember");
+    expect(result.skipped).toHaveLength(0);
+
+    const entries = galList();
+    expect(entries).toHaveLength(2);
+  });
+
+  it("galSync skips already-present entries", async () => {
+    const { galSet, galSync } = await getGal();
+    galSet("tps-rockit", "tps-rockit");
+
+    const branchDir = join(testRoot, "branch-office");
+    mkdirSync(join(branchDir, "tps-rockit"), { recursive: true });
+    writeFileSync(join(branchDir, "tps-rockit", "remote.json"), JSON.stringify({}));
+
+    const result = galSync();
+    expect(result.added).toHaveLength(0);
+    expect(result.skipped).toContain("tps-rockit");
+  });
+
+  it("galSync returns empty result when branch-office dir missing", async () => {
+    const { galSync } = await getGal();
+    const result = galSync();
+    expect(result.added).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("handles corrupted gal.json gracefully", async () => {
+    const { galList, galSet } = await getGal();
+    writeFileSync(join(testRoot, "gal.json"), "not valid json");
+    expect(galList()).toEqual([]);
+    // Can still write to a corrupted file
+    galSet("flint", "tps-rockit");
+    expect(galList()).toHaveLength(1);
+  });
+});

--- a/scripts/branch-supervisor.sh
+++ b/scripts/branch-supervisor.sh
@@ -25,11 +25,10 @@ else
 fi
 
 run_branch() {
-  # --nonono: skip nono process isolation check (not installed on all VMs)
   if [ -n "$TPS_SCRIPT" ]; then
-    TPS_BRANCH_DAEMON=1 "$TPS_BIN" "$TPS_SCRIPT" branch start --nonono
+    TPS_BRANCH_DAEMON=1 "$TPS_BIN" "$TPS_SCRIPT" branch start
   else
-    TPS_BRANCH_DAEMON=1 "$TPS_BIN" branch start --nonono
+    TPS_BRANCH_DAEMON=1 "$TPS_BIN" branch start
   fi
 }
 

--- a/scripts/branch-supervisor.sh
+++ b/scripts/branch-supervisor.sh
@@ -25,10 +25,11 @@ else
 fi
 
 run_branch() {
+  # --nonono: skip nono process isolation check (not installed on all VMs)
   if [ -n "$TPS_SCRIPT" ]; then
-    TPS_BRANCH_DAEMON=1 "$TPS_BIN" "$TPS_SCRIPT" branch start
+    TPS_BRANCH_DAEMON=1 "$TPS_BIN" "$TPS_SCRIPT" branch start --nonono
   else
-    TPS_BRANCH_DAEMON=1 "$TPS_BIN" branch start
+    TPS_BRANCH_DAEMON=1 "$TPS_BIN" branch start --nonono
   fi
 }
 

--- a/scripts/branch-supervisor.sh
+++ b/scripts/branch-supervisor.sh
@@ -73,8 +73,11 @@ while true; do
   BRANCH_PID=$!
 
   # Wait for it to exit (or supervisor to be signaled)
+  # Use set +e so SIGKILL exit doesn't abort the script
+  set +e
   wait $BRANCH_PID 2>/dev/null
   EXIT_CODE=$?
+  set -e
 
   # Exit code 0 means intentional stop (e.g. tps branch stop sent SIGTERM)
   if [ $EXIT_CODE -eq 0 ]; then

--- a/scripts/setup-branch-service.sh
+++ b/scripts/setup-branch-service.sh
@@ -42,9 +42,10 @@ if [ -f "$SUPERVISOR_PID_FILE" ]; then
   fi
 fi
 
-# Start supervisor in background, detached from terminal
+# Start supervisor in a new session (setsid) so SIGKILL to the branch child
+# does not propagate up to the supervisor process group.
 log "Starting branch supervisor..."
-nohup "$SUPERVISOR_SCRIPT" >> "$SUPERVISOR_LOG" 2>&1 &
+setsid nohup "$SUPERVISOR_SCRIPT" >> "$SUPERVISOR_LOG" 2>&1 &
 SUPERVISOR_PID=$!
 
 # Give it a moment to write its PID file


### PR DESCRIPTION
## Summary

Implements Phase 1 of ops-119: static GAL file with CLI commands and mail routing integration.

## Changes

**`src/utils/gal.ts`** (new)
- `galLookup(agentId)` → `branchId | null` — the core routing primitive
- `galSet` / `galRemove` / `galList` — CRUD on `~/.tps/gal.json`
- `galSync()` — seeds GAL from existing `branch-office/` registrations (idempotent, no overwrites)

**`src/commands/gal.ts`** (new)
- `tps gal list` — tabular output (agent / branch / updated)
- `tps gal set <agentId> <branchId>` — upsert mapping
- `tps gal remove <agentId>` — remove entry
- `tps gal sync` — seed from branch-office dirs

**`src/commands/mail.ts`**
- GAL lookup inserted before branch-office directory check in `send` handler
- Resolves agent name → physical branch ID transparently; logs resolved branch in output
- Falls back to direct lookup if no GAL entry

**`bin/tps.ts`**
- `gal` command dispatch + help text

**`test/gal.test.ts`**
- 10 tests: all CRUD ops, sync, empty/corrupted file handling

## Test results
661 pass, 3 fail (all pre-existing on main), 2 todo

Closes #236