### PR TITLE
feat: structured task envelope format for TPS mail (ops-117)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -122,6 +122,13 @@ const cli = meow(
       priority: { type: "string" },
       version: { type: "string" },
       verbose: { type: "boolean", default: false },
+      // Task envelope flags (mail send --task)
+      task: { type: "string" },
+      taskId: { type: "string" },
+      title: { type: "string" },
+      spec: { type: "string" },
+      output: { type: "string" },
+      taskContext: { type: "string" },
     },
   }
 );
@@ -654,6 +661,15 @@ async function main() {
           maxAge: getFlag("max-age"),
           pr: getFlag("pr") ? Number(getFlag("pr")) : undefined,
           status: getFlag("status") as any,
+          // Task envelope flags
+          task: cli.flags.task as string | undefined,
+          taskId: cli.flags.taskId as string | undefined,
+          title: cli.flags.title as string | undefined,
+          spec: cli.flags.spec as string | undefined,
+          branch: typeof cli.flags.branch === "string" ? cli.flags.branch : undefined,
+          priority: cli.flags.priority as string | undefined,
+          output: cli.flags.output as string | undefined,
+          taskContext: cli.flags.taskContext as string | undefined,
         });
       }
       break;

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -8,11 +8,21 @@ import { existsSync, readdirSync, readFileSync, renameSync, statSync, watch } fr
 import { loadHostIdentityId } from "../utils/identity.js";
 import { queueOutboxMessage } from "../utils/outbox.js";
 import { galLookup } from "../utils/gal.js";
+import { parseTaskEnvelope, formatTaskEnvelope, createTaskEnvelope } from "../utils/task-envelope.js";
 
 interface MailArgs {
   action: "send" | "check" | "list" | "stats" | "log" | "read" | "watch" | "search" | "relay" | "topic" | "subscribe" | "unsubscribe" | "publish" | "ack" | "nack" | "gc";
   agent?: string;
   message?: string;
+  // Task envelope flags
+  task?: string;
+  taskId?: string;
+  title?: string;
+  spec?: string;
+  branch?: string;
+  priority?: string;
+  output?: string;
+  taskContext?: string;
   messageId?: string;
   json?: boolean;
   count?: boolean;
@@ -88,10 +98,34 @@ export async function runMail(args: MailArgs): Promise<void> {
   switch (args.action) {
     case "send": {
       const to = validateAgent(args.agent);
-      if (!args.message) {
-        console.error("Usage: tps mail send <agent> <message>");
-        process.exit(1);
+
+      // Build message body: --task flag constructs a task envelope
+      let messageBody: string;
+      if (args.task) {
+        try {
+          messageBody = createTaskEnvelope(`task.${args.task}`, {
+            taskId: args.taskId,
+            title: args.title,
+            spec: args.spec,
+            branch: args.branch,
+            priority: args.priority,
+            output: args.output,
+            context: args.taskContext,
+          });
+        } catch (err) {
+          console.error(`Task envelope error: ${(err as Error).message}`);
+          process.exit(1);
+        }
+      } else {
+        if (!args.message) {
+          console.error("Usage: tps mail send <agent> <message>");
+          process.exit(1);
+        }
+        messageBody = args.message;
       }
+      // Reassign for downstream use
+      args.message = messageBody;
+
       const from = await resolveAgentId();
 
       // Branch mode: queue outbound to be picked up by host on next connect
@@ -167,7 +201,8 @@ export async function runMail(args: MailArgs): Promise<void> {
       } else {
         for (const m of messages) {
           console.log(`📬 ${m.from} → ${m.to}  ${m.timestamp}`);
-          console.log(m.body);
+          const taskEnv = parseTaskEnvelope(m.body);
+          console.log(taskEnv ? formatTaskEnvelope(taskEnv) : m.body);
           console.log("---");
         }
       }
@@ -199,7 +234,13 @@ export async function runMail(args: MailArgs): Promise<void> {
         } else {
           for (const m of visible) {
             const marker = m.read ? "📖" : "📬";
-            console.log(`${marker} [${m.id.slice(0, 8)}] ${m.from} → ${m.to}  ${m.timestamp}`);
+            const taskEnv = parseTaskEnvelope(m.body);
+            const summary = taskEnv
+              ? `  ${formatTaskEnvelope(taskEnv)}`
+              : m.body
+                ? `  ${m.body.slice(0, 60)}${m.body.length > 60 ? "…" : ""}`
+                : "";
+            console.log(`${marker} [${m.id.slice(0, 8)}] ${m.from} → ${m.to}  ${m.timestamp}${summary}`);
           }
         }
       }
@@ -256,6 +297,10 @@ export async function runMail(args: MailArgs): Promise<void> {
         const marker = found.read ? "📖" : "📬";
         console.log(`${marker} ${found.from} → ${found.to}  ${found.timestamp}`);
         console.log(`ID: ${found.id}`);
+        const taskEnv = parseTaskEnvelope(found.body);
+        if (taskEnv) {
+          console.log(`Task: ${formatTaskEnvelope(taskEnv)}`);
+        }
         console.log("---");
         console.log(found.body);
       }

--- a/packages/cli/src/utils/task-envelope.ts
+++ b/packages/cli/src/utils/task-envelope.ts
@@ -1,0 +1,93 @@
+/**
+ * task-envelope.ts — Structured task message format for TPS mail.
+ *
+ * Task messages are JSON with a `type` field starting with "task.".
+ * Plain text mail is unchanged — no breaking changes to existing flow.
+ */
+
+export interface TaskEnvelope {
+  type: string;
+  taskId: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Try to parse a mail body as a task envelope.
+ * Returns the envelope if valid, null if plain text or non-task JSON.
+ */
+export function parseTaskEnvelope(body: string): TaskEnvelope | null {
+  if (!body || typeof body !== "string") return null;
+  const trimmed = body.trim();
+  if (!trimmed.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      typeof parsed.type === "string" &&
+      parsed.type.startsWith("task.") &&
+      typeof parsed.taskId === "string" &&
+      parsed.taskId.length > 0
+    ) {
+      return parsed as TaskEnvelope;
+    }
+  } catch {
+    // Not valid JSON
+  }
+  return null;
+}
+
+/**
+ * Format a task envelope as a human-readable one-liner.
+ * e.g. "[task.assign] ops-119: Global Address List (P0)"
+ */
+export function formatTaskEnvelope(envelope: TaskEnvelope): string {
+  const parts: string[] = [`[${envelope.type}] ${envelope.taskId}`];
+
+  const title = typeof envelope.title === "string" ? envelope.title : null;
+  if (title) parts.push(`: ${title}`);
+
+  const priority = typeof envelope.priority === "string" ? envelope.priority : null;
+  if (priority) parts.push(` (${priority})`);
+
+  const pr = typeof envelope.pr === "string" ? envelope.pr : null;
+  const verdict = typeof envelope.verdict === "string" ? envelope.verdict : null;
+  if (pr && !title) parts.push(`: ${pr}`);
+  if (verdict) parts.push(` — ${verdict}`);
+
+  const reason = typeof envelope.reason === "string" ? envelope.reason : null;
+  if (reason) parts.push(`: ${reason}`);
+
+  const message = typeof envelope.message === "string" ? envelope.message : null;
+  if (message && !title && !pr) parts.push(`: ${message}`);
+
+  return parts.join("");
+}
+
+/**
+ * Construct a task envelope JSON string for sending.
+ * Validates required fields before serializing.
+ */
+export function createTaskEnvelope(
+  type: string,
+  fields: Record<string, unknown>
+): string {
+  if (!type || !type.startsWith("task.")) {
+    throw new Error(`Invalid task type: "${type}" — must start with "task."`);
+  }
+  const taskId = fields.taskId ?? fields["task-id"];
+  if (!taskId || typeof taskId !== "string" || taskId.trim().length === 0) {
+    throw new Error("taskId is required and must be a non-empty string");
+  }
+  const envelope: TaskEnvelope = {
+    type,
+    taskId: String(taskId).trim(),
+    ...fields,
+  };
+  // Remove undefined values for clean JSON
+  const clean = Object.fromEntries(
+    Object.entries(envelope).filter(([, v]) => v !== undefined)
+  );
+  return JSON.stringify(clean);
+}

--- a/packages/cli/test/task-envelope.test.ts
+++ b/packages/cli/test/task-envelope.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "bun:test";
+import { parseTaskEnvelope, formatTaskEnvelope, createTaskEnvelope } from "../src/utils/task-envelope.js";
+
+describe("parseTaskEnvelope", () => {
+  it("parses a valid task.assign envelope", () => {
+    const body = JSON.stringify({
+      type: "task.assign",
+      taskId: "ops-119",
+      title: "Global Address List",
+      priority: "P0",
+    });
+    const result = parseTaskEnvelope(body);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("task.assign");
+    expect(result!.taskId).toBe("ops-119");
+    expect(result!.title).toBe("Global Address List");
+  });
+
+  it("parses task.done envelope", () => {
+    const body = JSON.stringify({
+      type: "task.done",
+      taskId: "ops-117",
+      pr: "https://github.com/tpsdev-ai/cli/pull/240",
+      message: "All tests passing.",
+    });
+    const result = parseTaskEnvelope(body);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("task.done");
+  });
+
+  it("returns null for plain text", () => {
+    expect(parseTaskEnvelope("hello there")).toBeNull();
+    expect(parseTaskEnvelope("Mail delivered to remote branch 'anvil'.")).toBeNull();
+  });
+
+  it("returns null for non-task JSON", () => {
+    expect(parseTaskEnvelope(JSON.stringify({ foo: "bar" }))).toBeNull();
+    expect(parseTaskEnvelope(JSON.stringify({ type: "other.thing", taskId: "x" }))).toBeNull();
+  });
+
+  it("returns null for JSON array", () => {
+    expect(parseTaskEnvelope(JSON.stringify([1, 2, 3]))).toBeNull();
+  });
+
+  it("returns null for empty or missing taskId", () => {
+    expect(parseTaskEnvelope(JSON.stringify({ type: "task.assign" }))).toBeNull();
+    expect(parseTaskEnvelope(JSON.stringify({ type: "task.assign", taskId: "" }))).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseTaskEnvelope("{ not valid json")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseTaskEnvelope("")).toBeNull();
+  });
+});
+
+describe("formatTaskEnvelope", () => {
+  it("formats task.assign with title and priority", () => {
+    const result = formatTaskEnvelope({
+      type: "task.assign",
+      taskId: "ops-119",
+      title: "Global Address List",
+      priority: "P0",
+    });
+    expect(result).toBe("[task.assign] ops-119: Global Address List (P0)");
+  });
+
+  it("formats task.assign without priority", () => {
+    const result = formatTaskEnvelope({
+      type: "task.assign",
+      taskId: "ops-117",
+      title: "Task Delivery Format",
+    });
+    expect(result).toBe("[task.assign] ops-117: Task Delivery Format");
+  });
+
+  it("formats task.done with pr", () => {
+    const result = formatTaskEnvelope({
+      type: "task.done",
+      taskId: "ops-119",
+      pr: "https://github.com/tpsdev-ai/cli/pull/238",
+    });
+    expect(result).toContain("[task.done] ops-119");
+    expect(result).toContain("https://github.com");
+  });
+
+  it("formats task.blocked with reason", () => {
+    const result = formatTaskEnvelope({
+      type: "task.blocked",
+      taskId: "ops-117",
+      reason: "Can't access ops repo",
+    });
+    expect(result).toContain("[task.blocked] ops-117");
+    expect(result).toContain("Can't access ops repo");
+  });
+
+  it("formats task.review.done with verdict", () => {
+    const result = formatTaskEnvelope({
+      type: "task.review.done",
+      taskId: "ops-119",
+      pr: "https://github.com/tpsdev-ai/cli/pull/238",
+      verdict: "approved",
+    });
+    expect(result).toContain("approved");
+  });
+
+  it("formats minimal envelope (type + taskId only)", () => {
+    const result = formatTaskEnvelope({ type: "task.ack", taskId: "ops-100" });
+    expect(result).toBe("[task.ack] ops-100");
+  });
+});
+
+describe("createTaskEnvelope", () => {
+  it("creates valid task.assign JSON", () => {
+    const body = createTaskEnvelope("task.assign", {
+      taskId: "ops-120",
+      title: "Bootstrap script",
+      priority: "P1",
+    });
+    const parsed = JSON.parse(body);
+    expect(parsed.type).toBe("task.assign");
+    expect(parsed.taskId).toBe("ops-120");
+    expect(parsed.title).toBe("Bootstrap script");
+  });
+
+  it("round-trips through parseTaskEnvelope", () => {
+    const body = createTaskEnvelope("task.assign", { taskId: "ops-120", title: "Test" });
+    const envelope = parseTaskEnvelope(body);
+    expect(envelope).not.toBeNull();
+    expect(envelope!.taskId).toBe("ops-120");
+  });
+
+  it("throws for invalid type", () => {
+    expect(() => createTaskEnvelope("not-a-task", { taskId: "x" })).toThrow();
+    expect(() => createTaskEnvelope("", { taskId: "x" })).toThrow();
+  });
+
+  it("throws for missing taskId", () => {
+    expect(() => createTaskEnvelope("task.assign", {})).toThrow();
+    expect(() => createTaskEnvelope("task.assign", { taskId: "" })).toThrow();
+  });
+
+  it("strips undefined fields from output", () => {
+    const body = createTaskEnvelope("task.assign", {
+      taskId: "ops-120",
+      title: "Test",
+      spec: undefined,
+      branch: undefined,
+    });
+    const parsed = JSON.parse(body);
+    expect(parsed.spec).toBeUndefined();
+    expect(parsed.branch).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements ops-117 Phase 1: parse, display, and send structured task envelopes over TPS mail. No breaking changes to plain text mail.

## New: `src/utils/task-envelope.ts`
- `parseTaskEnvelope(body)` — returns `TaskEnvelope | null`; only matches JSON with `type` starting with `task.` and non-empty `taskId`
- `formatTaskEnvelope(envelope)` — one-liner: `[task.assign] ops-119: Global Address List (P0)`
- `createTaskEnvelope(type, fields)` — validated JSON builder; throws on bad type or missing taskId

## Updated: `src/commands/mail.ts`
- `check`: task messages show formatted summary instead of raw JSON body
- `list`: task messages show formatted summary inline with message header
- `read`: adds `Task: [type] id — title` header before body for task messages
- `send`: `--task` flag constructs task envelope as mail body

## Updated: `bin/tps.ts`
- Added `--task`, `--task-id`, `--title`, `--spec`, `--branch`, `--priority`, `--output`, `--task-context` flags

## Tests
19 new tests, 680 total passing, 3 pre-existing failures on main.

## Example usage
```
tps mail send anvil --task assign --task-id ops-120 --title "Bootstrap script" --priority P1
# → body: {"type":"task.assign","taskId":"ops-120","title":"Bootstrap script","priority":"P1"}

tps mail list anvil
# → 📬 [dcf847b7] rockit → anvil  2026-03-13T21:29  [task.assign] ops-117: Task Delivery Format (P0)
```