### PR TITLE
fix: use branch ID as wire 'to' field for GAL-routed mail (#240)

### DIFF
--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -121,7 +121,10 @@ export async function runMail(args: MailArgs): Promise<void> {
       );
       if (existsSync(remoteJsonPath)) {
         assertValidBody(args.message);
-        await deliverToRemoteBranch(effectiveTo, { to, from, body: args.message });
+        // Use effectiveTo (branch ID) as the wire 'to' field so the branch daemon
+        // stores mail under its own identity dir (e.g. "tps-anvil"), not the
+        // GAL logical name (e.g. "anvil"). Fixes #240.
+        await deliverToRemoteBranch(effectiveTo, { to: effectiveTo, from, body: args.message });
         if (args.json) {
           console.log(JSON.stringify({ status: "sent", to, transport: "remote", resolvedBranch: effectiveTo }));
         } else {


### PR DESCRIPTION
## Problem

When `tps mail send anvil ...` routes via GAL to `tps-anvil`, the wire message `to` field was still `"anvil"` (the logical name). The branch daemon stores mail under `body.to`, creating `~/.tps/mail/anvil/` instead of `~/.tps/mail/tps-anvil/`.

## Fix

One-line change in `mail.ts`: pass `effectiveTo` (the resolved branch ID) as the wire `to` field instead of the original logical name.

```ts
// Before
deliverToRemoteBranch(effectiveTo, { to, from, body: args.message })

// After  
deliverToRemoteBranch(effectiveTo, { to: effectiveTo, from, body: args.message })
```

661 passing, 3 pre-existing failures.

Fixes #240