### PR TITLE
feat(ops-115): self-healing branch connectivity — Phase 1

### DIFF
--- a/packages/cli/src/commands/branch.ts
+++ b/packages/cli/src/commands/branch.ts
@@ -257,6 +257,8 @@ async function runStart(): Promise<void> {
     writeBranchState({ connectedAt: new Date().toISOString(), lastSeen: new Date().toISOString(), messagesReceived: 0, messagesPushed: 0 });
 
     if (msg.type === MSG_HEARTBEAT) {
+      // Echo heartbeat back so host can track bidirectional liveness
+      await channel.send({ type: MSG_HEARTBEAT, seq: msg.seq, ts: new Date().toISOString(), body: {} }).catch(() => {});
       for (const item of drainOutbox()) {
         await channel.send({
           type: MSG_MAIL_DELIVER,

--- a/packages/cli/src/commands/office.ts
+++ b/packages/cli/src/commands/office.ts
@@ -471,12 +471,32 @@ export async function runOffice(args: OfficeArgs): Promise<void> {
         }
         for (const s of states) {
           const alive = connectionAlive(s.branch);
-          const age = Math.round((Date.now() - new Date(s.connectedAt).getTime()) / 1000);
+          const ageSec = Math.round((Date.now() - new Date(s.connectedAt).getTime()) / 1000);
+          const uptime = ageSec < 60 ? `${ageSec}s` : ageSec < 3600 ? `${Math.floor(ageSec / 60)}m` : `${Math.floor(ageSec / 3600)}h ${Math.floor((ageSec % 3600) / 60)}m`;
+          const lastHb = s.lastHeartbeatSent
+            ? Math.round((Date.now() - new Date(s.lastHeartbeatSent).getTime()) / 1000)
+            : null;
+          const hbStr = lastHb !== null ? `${lastHb}s ago` : "never";
           const lastAck = s.lastHeartbeatAck
             ? Math.round((Date.now() - new Date(s.lastHeartbeatAck).getTime()) / 1000) + "s ago"
             : "never";
-          const anomaly = !alive ? " ⚠️  STALE (PID dead)" : s.reconnectCount > 3 ? ` ⚠️  ${s.reconnectCount} reconnects` : "";
-          console.log(`${s.branch.padEnd(12)} ${alive ? "connected" : "STALE"}  ${age}s  ↑${s.messagesSent}msg  ↓${s.messagesReceived}msg  last ack: ${lastAck}${anomaly}`);
+          const status = !alive ? "🔴 STALE" : "🟢 connected";
+          const anomaly = !alive ? " (PID dead)" : s.reconnectCount > 3 ? ` (${s.reconnectCount} reconnects)` : "";
+          console.log(`${s.branch}:`);
+          console.log(`  Status:     ${status}${anomaly}`);
+          console.log(`  Uptime:     ${uptime} (since ${s.connectedAt})`);
+          console.log(`  Heartbeat:  sent ${hbStr}, ack ${lastAck}`);
+          console.log(`  Reconnects: ${s.reconnectCount}`);
+          console.log(`  Messages:   ↑${s.messagesSent} sent / ↓${s.messagesReceived} received`);
+          if (s.services && s.services.length > 0) {
+            console.log(`  Services:`);
+            for (const svc of s.services) {
+              const icon = svc.status === "healthy" ? "✅" : svc.status === "unhealthy" ? "❌" : "❓";
+              const lastCheck = svc.lastCheck ? `, checked ${Math.round((Date.now() - new Date(svc.lastCheck).getTime()) / 1000)}s ago` : "";
+              console.log(`    ${icon} ${svc.name} (${svc.status}${lastCheck}${svc.error ? `, error: ${svc.error}` : ""})`);
+            }
+          }
+          console.log();
         }
         return;
       }

--- a/packages/cli/src/utils/connection-state.ts
+++ b/packages/cli/src/utils/connection-state.ts
@@ -4,6 +4,14 @@ import { join } from "node:path";
 
 const connectionsDir = () => join(process.env.HOME ?? homedir(), ".tps", "connections");
 
+export interface ServiceHealth {
+  name: string;
+  status: "healthy" | "unhealthy" | "unknown";
+  lastCheck: string | null;
+  lastHealthy: string | null;
+  error?: string;
+}
+
 export interface HostConnectionState {
   branch: string;
   connectedAt: string;
@@ -15,6 +23,7 @@ export interface HostConnectionState {
   messagesSent: number;
   messagesReceived: number;
   pid: number;
+  services?: ServiceHealth[];
 }
 
 export interface BranchConnectionState {
@@ -33,8 +42,8 @@ function branchStatePath(): string {
 }
 
 export function writeHostState(state: HostConnectionState): void {
-  mkdirSync(connectionsDir(), { recursive: true });
-  writeFileSync(hostStatePath(state.branch), JSON.stringify(state, null, 2), "utf-8");
+  mkdirSync(connectionsDir(), { recursive: true, mode: 0o700 });
+  writeFileSync(hostStatePath(state.branch), JSON.stringify(state, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 export function readHostState(branch: string): HostConnectionState | null {

--- a/packages/cli/src/utils/relay.ts
+++ b/packages/cli/src/utils/relay.ts
@@ -12,7 +12,8 @@ import { WireDeliveryTransport } from "./wire-delivery.js";
 import { loadHostIdentity, lookupBranch } from "./identity.js";
 import { MSG_MAIL_DELIVER, MSG_MAIL_ACK, MSG_HEARTBEAT, MailDeliverBodySchema } from "./wire-mail.js";
 import { registerServiceProxyHandler } from "./service-proxy-host.js";
-import { clearHostState, writeHostState, type HostConnectionState } from "./connection-state.js";
+import { clearHostState, writeHostState, type HostConnectionState, type ServiceHealth } from "./connection-state.js";
+import { listServices } from "./service-registry.js";
 import snooplogg from "snooplogg";
 const { log: slog, warn: swarn, error: serror } = snooplogg("tps:relay");
 
@@ -468,6 +469,23 @@ export async function syncRemoteBranch(branchId: string): Promise<{ received: nu
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const RECONNECT_BASE_MS = 2_000;
 const RECONNECT_MAX_MS = 60_000;
+const SERVICE_HEALTH_INTERVAL_MS = 5 * 60_000; // 5 minutes
+
+async function probeServiceHealth(): Promise<ServiceHealth[]> {
+  const services = listServices();
+  const results: ServiceHealth[] = [];
+  const now = new Date().toISOString();
+  for (const svc of services) {
+    try {
+      const url = svc.localPort ? `http://127.0.0.1:${svc.localPort}/` : svc.url;
+      const res = await fetch(url, { method: "GET", signal: AbortSignal.timeout(5_000) });
+      results.push({ name: svc.name, status: "healthy", lastCheck: now, lastHealthy: now });
+    } catch (err: any) {
+      results.push({ name: svc.name, status: "unhealthy", lastCheck: now, lastHealthy: null, error: err?.message?.slice(0, 100) });
+    }
+  }
+  return results;
+}
 
 export async function connectAndKeepAlive(
   branchId: string,
@@ -528,17 +546,35 @@ export async function connectAndKeepAlive(
 
         registerServiceProxyHandler(channel);
 
+        // Periodic service health probes
+        const healthProbe = setInterval(async () => {
+          if (stopped || !channel.isAlive()) return;
+          try {
+            const health = await probeServiceHealth();
+            state.services = health;
+            writeHostState(state);
+          } catch {}
+        }, SERVICE_HEALTH_INTERVAL_MS);
+        // Initial probe on connect
+        probeServiceHealth().then((h) => { state.services = h; writeHostState(state); }).catch(() => {});
+
         const handler = (msg: TpsMessage) => {
           state.messagesReceived++;
-          state.lastHeartbeatAck = new Date().toISOString();
-          writeHostState(state);
-          if (msg.type === MSG_MAIL_DELIVER) {
+          const now = new Date().toISOString();
+          if (msg.type === MSG_HEARTBEAT) {
+            // Heartbeat echo from branch — track as ack
+            state.lastHeartbeatAck = now;
+          } else if (msg.type === MSG_MAIL_DELIVER) {
+            state.lastHeartbeatAck = now; // any traffic = alive
             const parsed = MailDeliverBodySchema.safeParse(msg.body);
             if (parsed.success) {
               const b = parsed.data;
               try { sendMessage(b.to, b.content, b.from); } catch {}
             }
+          } else {
+            state.lastHeartbeatAck = now;
           }
+          writeHostState(state);
           opts.onMessage?.(msg);
         };
         channel.onMessage(handler);
@@ -547,6 +583,7 @@ export async function connectAndKeepAlive(
           await new Promise((r) => setTimeout(r, 1000));
         }
         clearInterval(hb);
+        clearInterval(healthProbe);
         channel.offMessage(handler);
         try { await channel.close(); } catch {}
         currentChannel = null;


### PR DESCRIPTION
## Summary

Makes branch office connections observable and fixes blind spots in liveness tracking.

### Changes

**Branch heartbeat echo** (`branch.ts`):
Branch now echoes `MSG_HEARTBEAT` back to host on each heartbeat. Previously the branch only responded when it had outbox mail to drain, leaving `lastHeartbeatAck` permanently null.

**Enhanced `tps office status`** (`office.ts`):
```
tps-anvil:
  Status:     🟢 connected
  Uptime:     14h 32m (since 2026-03-16T15:51:15.675Z)
  Heartbeat:  sent 12s ago, ack 12s ago
  Reconnects: 1
  Messages:   ↑2,589 sent / ↓2,589 received
  Services:
    ✅ flair (healthy, checked 45s ago)
```

**Service health probes** (`relay.ts`):
- Probes all registered services every 5 minutes via HTTP
- Initial probe on connect
- Health status written to connection state file
- Visible in `tps office status`

**Connection state improvements** (`connection-state.ts`):
- `ServiceHealth` interface added
- File permissions fixed to 0600 (was inconsistent)

### Files
- `packages/cli/src/commands/branch.ts` — heartbeat echo (2 lines)
- `packages/cli/src/commands/office.ts` — enhanced status display
- `packages/cli/src/utils/connection-state.ts` — ServiceHealth type, 0600 perms
- `packages/cli/src/utils/relay.ts` — health probes, proper ack tracking

### Testing
717 pass, 1 pre-existing fail (nono PATH fallback — unrelated). No regressions.