### PR TITLE
fix: relay deliverToSandbox writes to mail/new not mail/inbox/new

### DIFF
--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import { sanitizeIdentifier, sanitizeFreeText, sanitizeModelIdentifier } from "../schema/sanitizer.js";
 import { workspacePath as resolveWorkspacePath, resolveTeamId, branchRoot as workspaceRoot } from "../utils/workspace.js";
 import { runCommandUnderNono } from "../utils/nono.js";
-import { deliverToSandbox } from "../utils/relay.js";
+import { deliverToSandbox, resolveAgentMailRoot } from "../utils/relay.js";
 import { readOpenClawConfig, findOpenClawConfig, type OpenClawConfig } from "../utils/config.js";
 
 export interface BootstrapArgs {
@@ -168,10 +168,12 @@ function healthGateway(): boolean {
   return runCommandUnderNono("tps-bootstrap", {}, ["openclaw", "gateway", "status"]) === 0;
 }
 
-function healthMail(teamWorkspace: string, teamId: string): boolean {
-  const inbox = join(teamWorkspace, "mail", "inbox", "new");
-  mkdirSync(inbox, { recursive: true });
-  const before = readdirSync(inbox).filter((f) => f.endsWith(".json")).length;
+function healthMail(_teamWorkspace: string, teamId: string): boolean {
+  // Use resolveAgentMailRoot() — same path derivation as deliverToSandbox()
+  const mailRoot = resolveAgentMailRoot(teamId);
+  const freshDir = join(mailRoot, "new");
+  mkdirSync(freshDir, { recursive: true });
+  const before = readdirSync(freshDir).filter((f) => f.endsWith(".json")).length;
 
   const msg = {
     id: randomUUID(),
@@ -187,24 +189,25 @@ function healthMail(teamWorkspace: string, teamId: string): boolean {
     return false;
   }
 
-  const after = readdirSync(inbox).filter((f) => f.endsWith(".json")).length;
+  const after = readdirSync(freshDir).filter((f) => f.endsWith(".json")).length;
 
   if (after <= before) {
     return false;
   }
 
-  // mark probe as received by attempting to move one file to cur (read path) and parse
+  // mark probe as received by moving one file to cur and parsing
   try {
-    const files = readdirSync(inbox)
+    const curDir = join(mailRoot, "cur");
+    mkdirSync(curDir, { recursive: true });
+    const files = readdirSync(freshDir)
       .filter((f) => f.endsWith(".json"))
       .sort()
       .reverse();
-    const probe = join(inbox, files[0]!);
+    const probe = join(freshDir, files[0]!);
     const raw = readFileSync(probe, "utf-8");
     const parsed = JSON.parse(raw);
     if (!parsed.from?.startsWith("system:")) return false;
-    mkdirSync(join(teamWorkspace, "mail", "inbox", "cur"), { recursive: true });
-    renameSync(probe, join(teamWorkspace, "mail", "inbox", "cur", files[0]!));
+    renameSync(probe, join(curDir, files[0]!));
   } catch {
     return false;
   }
@@ -212,10 +215,7 @@ function healthMail(teamWorkspace: string, teamId: string): boolean {
   return true;
 }
 
-function sendIntroduction(teamId: string, teamWorkspace: string, body: string): void {
-  const inbox = join(teamWorkspace, "mail", "inbox", "new");
-  mkdirSync(inbox, { recursive: true });
-
+function sendIntroduction(teamId: string, _teamWorkspace: string, body: string): void {
   deliverToSandbox(teamId, {
     id: randomUUID(),
     from: "system:bootstrap",

--- a/packages/cli/src/utils/relay.ts
+++ b/packages/cli/src/utils/relay.ts
@@ -29,6 +29,11 @@ export interface RelayMessage {
   error?: string;
 }
 
+/** Returns the mail root dir for an agent (branch-office or team workspace). Used by deliverToSandbox and external callers that need to read delivered messages. */
+export function resolveAgentMailRoot(agentId: string): string {
+  return resolveDeliveryPath(agentId);
+}
+
 function resolveDeliveryPath(agentId: string): string {
   const branchDir = join(process.env.HOME || homedir(), ".tps", "branch-office");
   if (!existsSync(branchDir)) return join(branchDir, agentId, "mail");
@@ -605,11 +610,40 @@ export async function connectAndKeepAlive(
   };
 }
 
+/**
+ * One-time migration: move any orphaned messages from the old
+ * `mail/inbox/new/` path into the canonical `mail/new/` path.
+ * Safe to call on every delivery — exits early if nothing to migrate.
+ */
+function migrateOrphanedInboxMessages(mailRoot: string): void {
+  const legacyDir = join(mailRoot, "inbox", "new");
+  if (!existsSync(legacyDir)) return;
+  const freshDir = join(mailRoot, "new");
+  try {
+    const files = readdirSync(legacyDir).filter((f) => f.endsWith(".json"));
+    for (const f of files) {
+      const src = join(legacyDir, f);
+      const dst = join(freshDir, f);
+      if (!existsSync(dst)) {
+        renameSync(src, dst);
+      }
+    }
+  } catch {
+    // Non-fatal — best-effort migration
+  }
+}
+
 export function deliverToSandbox(agentId: string, message: RelayMessage): void {
   assertAgent(agentId);
-  const root = branchRoot(agentId);
-  const inboxNew = join(root, "inbox", "new");
-  ensureDir(inboxNew);
+
+  // branchRoot() returns the mail root (e.g. ~/.tps/branch-office/<agent>/mail or team workspace/mail)
+  // Messages always go to <mailRoot>/new/ — this matches where tps mail check reads from.
+  const mailRoot = branchRoot(agentId);
+  const freshDir = join(mailRoot, "new");
+  ensureDir(freshDir);
+
+  // Migrate any orphaned messages from old inbox/new/ path on first delivery
+  migrateOrphanedInboxMessages(mailRoot);
 
   const payload = {
     id: message.id || randomUUID(),
@@ -622,5 +656,5 @@ export function deliverToSandbox(agentId: string, message: RelayMessage): void {
   };
 
   const filename = `${timestampPrefix()}-${randomUUID()}.json`;
-  atomicWriteJson(join(inboxNew, filename), payload);
+  atomicWriteJson(join(freshDir, filename), payload);
 }

--- a/packages/cli/test/bootstrap.test.ts
+++ b/packages/cli/test/bootstrap.test.ts
@@ -103,7 +103,8 @@ exit 0
 
     expect(existsSync(join(tempRoot, ".tps", "bootstrap-state", agentId, ".bootstrap-complete"))).toBe(true);
 
-    const mailDir = join(workspace, "mail", "inbox", "new");
+    // Canonical path: branch-office/<agent>/mail/new/ (matches getInbox().fresh)
+    const mailDir = join(workspace, "mail", "new");
     const mailFiles = readdirSync(mailDir).filter((f) => f.endsWith(".json"));
     expect(mailFiles.length).toBeGreaterThanOrEqual(1);
 

--- a/packages/cli/test/relay-remote.test.ts
+++ b/packages/cli/test/relay-remote.test.ts
@@ -81,7 +81,8 @@ describe("handleIncomingMail", () => {
   });
 
   test("delivers valid mail to local inbox", async () => {
-    const inbox = join(tmpDir, ".tps", "branch-office", "local-agent", "mail", "inbox", "new");
+    // Canonical path: branch-office/<agent>/mail/new/ (matches getInbox().fresh)
+    const inbox = join(tmpDir, ".tps", "branch-office", "local-agent", "mail", "new");
     mkdirSync(inbox, { recursive: true });
 
     const { handleIncomingMail } = await import("../src/utils/relay.js");

--- a/packages/cli/test/relay.test.ts
+++ b/packages/cli/test/relay.test.ts
@@ -104,14 +104,19 @@ describe("relay utils", () => {
     expect(curFiles.length).toBe(1);
   });
 
-  test("deliverToSandbox writes to inbox/new atomically", async () => {
+  test("deliverToSandbox writes to mail/new (canonical inbox path)", async () => {
+    // Pre-create the branch-office mail root so getInbox() treats brancha as a branch agent
+    const branchMail = join(root, ".tps", "branch-office", "brancha", "mail");
+    mkdirSync(branchMail, { recursive: true });
+
     deliverToSandbox("brancha", {
       to: "brancha",
       from: "flint",
       body: "hi from host",
     });
 
-    const inbox = join(root, ".tps", "branch-office", "brancha", "mail", "inbox", "new");
+    // Canonical path: branch-office/<agent>/mail/new/ (matches getInbox().fresh)
+    const inbox = join(branchMail, "new");
     const files = readdirSync(inbox).filter((f) => f.endsWith(".json"));
     expect(files.length).toBe(1);
     const payload = JSON.parse(readFileSync(join(inbox, files[0]!), "utf-8"));
@@ -146,7 +151,7 @@ describe("relay utils", () => {
     };
 
     mkdirSync(teamDir, { recursive: true });
-    mkdirSync(join(workspaceMail, "inbox", "new"), { recursive: true });
+    mkdirSync(join(workspaceMail, "new"), { recursive: true });
     writeJson(join(teamDir, "team.json"), teamSidecar);
 
     // Test delivery to member
@@ -156,8 +161,8 @@ describe("relay utils", () => {
       body: "hello team member",
     });
 
-    // Verify it landed in team workspace inbox
-    const inbox = join(workspaceMail, "inbox", "new");
+    // Canonical path: workspaceMail/new/ (matches getInbox().fresh)
+    const inbox = join(workspaceMail, "new");
     const files = readdirSync(inbox).filter((f) => f.endsWith(".json"));
     expect(files.length).toBe(1);
     const msg = JSON.parse(readFileSync(join(inbox, files[0]!), "utf-8"));


### PR DESCRIPTION
## Bug

`deliverToSandbox()` in `relay.ts` was writing delivered messages to:
```
~/.tps/branch-office/<agent>/mail/inbox/new/
```
But `tps mail check` reads from (via `getInbox().fresh`):
```
~/.tps/branch-office/<agent>/mail/new/
```
Result: every message delivered from a host over the tunnel was silently dropped — the inbox appeared empty.

## Fix

`deliverToSandbox` now derives the destination from `branchRoot(agentId)` (which returns the `mail/` root), then appends `/new/` — consistent with how `resolveDeliveryPath` was already working. Team-agent delivery (workspace/mail) is also correct since `branchRoot` handles the team sidecar lookup.

**One-time migration**: `migrateOrphanedInboxMessages()` runs on the first delivery and moves any existing files from the old `inbox/new/` into `new/` so no messages are lost.

**`resolveAgentMailRoot()`** is exported so `bootstrap.ts`'s mail health check can use the same path derivation instead of reimplementing it.

## Also fixed
- `bootstrap.ts` `healthMail()` and `sendIntroduction()` updated to use `resolveAgentMailRoot()`
- Tests updated to assert `mail/new/` (canonical) not `mail/inbox/new/` (buggy)

## Tests
720 passing, 0 failing.