### PR TITLE
fix: wire gcMessages into checkMessages for automatic mail cleanup

### DIFF
--- a/packages/cli/src/utils/mail.ts
+++ b/packages/cli/src/utils/mail.ts
@@ -204,6 +204,9 @@ export function checkMessages(agent: string, checkedOutBy = agent): MailMessage[
     messages.push(msg);
   }
 
+  // Best-effort GC: purge acked/expired messages older than 24h on every check
+  try { gcMessages(agent); } catch { /* never block delivery */ }
+
   return messages.sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1));
 }
 


### PR DESCRIPTION
## Problem
`gcMessages()` existed in `mail.ts` but was never called during normal mail checking. Processed messages accumulated in `cur/` indefinitely.

## Fix
Added a best-effort `gcMessages(agent)` call at the end of `checkMessages()`. On every `tps mail check`, acked/expired messages older than 24h are automatically purged.

## Testing
TypeScript compiles clean. One-line addition with try/catch — can't break mail delivery.

Credit: Anvil identified the missing wiring.