### PR TITLE
fix: mail parser handles corrupt JSON without crashing

### DIFF
--- a/packages/cli/src/commands/mail-watch.ts
+++ b/packages/cli/src/commands/mail-watch.ts
@@ -68,6 +68,11 @@ function readMessageSafe(filePath: string): MailMessage | null {
   } catch (err: unknown) {
     // ENOENT: file moved to cur/ between readdir and read — expected race
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    // JSON parse error: corrupt file — log and skip instead of crashing
+    if (err instanceof SyntaxError) {
+      console.error(`[mail-watch] skipping corrupt message ${filePath}: ${err.message}`);
+      return null;
+    }
     throw err;
   }
 }

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -286,8 +286,10 @@ export async function runMail(args: MailArgs): Promise<void> {
         if (!existsSync(dir)) continue;
         const files = readdirSync(dir).filter(f => f.endsWith(".json"));
         for (const f of files) {
-          const msg = JSON.parse(readFileSync(join(dir, f), "utf-8")) as MailMessage;
-          if (msg.id === id || msg.id.startsWith(id)) { found = msg; break; }
+          try {
+            const msg = JSON.parse(readFileSync(join(dir, f), "utf-8")) as MailMessage;
+            if (msg.id === id || msg.id.startsWith(id)) { found = msg; break; }
+          } catch { /* skip corrupt files */ }
         }
         if (found) break;
       }

--- a/packages/cli/src/utils/mail.ts
+++ b/packages/cli/src/utils/mail.ts
@@ -77,15 +77,18 @@ export function getInbox(agent: string): { root: string; tmp: string; fresh: str
 
 function readMessagesFromDir(dir: string, read: boolean): MailMessage[] {
   if (!existsSync(dir)) return [];
-  return readdirSync(dir)
-    .filter((f) => f.endsWith(".json"))
-    .map((f) => {
+  const messages: MailMessage[] = [];
+  for (const f of readdirSync(dir).filter((f) => f.endsWith(".json"))) {
+    try {
       const raw = readFileSync(join(dir, f), "utf-8");
       const msg = JSON.parse(raw) as MailMessage;
       msg.read = read;
-      return msg;
-    })
-    .sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1));
+      messages.push(msg);
+    } catch (err: any) {
+      console.error(`[mail] skipping corrupt message ${f}: ${err.message}`);
+    }
+  }
+  return messages.sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1));
 }
 
 function listMessageFiles(dir: string): string[] {
@@ -94,7 +97,11 @@ function listMessageFiles(dir: string): string[] {
 }
 
 function readMessageFile(path: string): MailMessage {
-  return JSON.parse(readFileSync(path, "utf-8")) as MailMessage;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as MailMessage;
+  } catch (err: any) {
+    throw new Error(`corrupt message file ${path}: ${err.message}`);
+  }
 }
 
 function writeMessageFile(path: string, msg: MailMessage): void {


### PR DESCRIPTION
## Summary
- `readMessagesFromDir()` in `utils/mail.ts`: catches JSON parse errors, logs warning, skips corrupt files
- `readMessageFile()`: wraps error with file path context
- `mail read` command: try/catch around per-file parse
- `mail-watch`: catches SyntaxError (corrupt JSON) in addition to ENOENT

Closes #260

## Test plan
- [x] Type check passes
- [ ] Create a malformed .json in an agent's inbox, verify `tps mail list` doesn't crash