### PR TITLE
fix: bun-incompatible setInterval keepalive in branch + office daemons

### DIFF
--- a/packages/cli/src/commands/branch.ts
+++ b/packages/cli/src/commands/branch.ts
@@ -384,8 +384,10 @@ async function runStart(): Promise<void> {
   process.on("SIGTERM", onShutdown);
   process.on("SIGINT", onShutdown);
 
-  // Keep alive
-  setInterval(() => {}, 60_000);
+  // Keep alive — bun does not treat a no-op interval as a ref'd handle, so the
+  // event loop drains and the daemon exits ~150ms after listen(). A
+  // never-resolving promise holds the loop until SIGTERM/SIGINT calls process.exit.
+  await new Promise<void>(() => {});
 }
 
 async function runStop(): Promise<void> {

--- a/packages/cli/src/commands/office.ts
+++ b/packages/cli/src/commands/office.ts
@@ -558,7 +558,8 @@ export async function runOffice(args: OfficeArgs): Promise<void> {
         stop();
         process.exit(0);
       });
-      setInterval(() => {}, 60_000);
+      // bun drops the no-op interval; hold the loop until SIGTERM/SIGINT.
+      await new Promise<void>(() => {});
       return;
     }
 
@@ -695,7 +696,8 @@ export async function runOffice(args: OfficeArgs): Promise<void> {
         await stop();
         process.exit(0);
       });
-      setInterval(() => {}, 60_000);
+      // bun drops the no-op interval; hold the loop until SIGTERM/SIGINT.
+      await new Promise<void>(() => {});
       return;
     }
 


### PR DESCRIPTION
## Summary

Replace `setInterval(() => {}, 60_000)` keep-alive with `await new Promise<void>(() => {})` in:
- `packages/cli/src/commands/branch.ts:388` (runStart, the branch daemon)
- `packages/cli/src/commands/office.ts:561,698` (office relay + connect)

Under bun, the no-op interval handle is dropped from the keep-alive set after `listenForHost`/`connectAndKeepAlive` returns, the event loop drains, and the daemon exits cleanly with code 0 within ~150ms of `listen()`. Reproduced via strace:

```
bind(13, ...) = 0
listen(13, 512) = 0
getsockname(13, ...) = 0  (x3)
exit_group(0)
```

No errors. No log output past `STARTED: Listening on …`. Just exit. The original long-running processes survived because they predated the dist build that introduced this no-op interval shape — restart-anywhere reveals the bug.

A never-resolving promise is the canonical bun-safe pattern; SIGTERM/SIGINT handlers continue to call `process.exit` for clean shutdown.

## Why this matters

`tps branch start` and `tps office connect <branch>` are the load-bearing daemons in the cross-host TPS mail topology. Both die silently after ~150ms on every restart under bun (which is now the default runtime per the build:binary scripts).

Discovered tonight while bringing Anvil's mail loop back online — branch service flapped through systemd restart-loops printing only "STARTED" with no error, and office-connect logged "Persistent connection active" then exited in 100ms. Reapplied the patch by hand to the on-host dist on rockit + tps-anvil; this PR makes it durable.

## Test plan

- [x] `tps branch start` foreground stays alive past the previous ~150ms exit (verified with `timeout 10` exits with 124 = timeout, not 0 = self-exit)
- [x] `tps office connect <branch>` foreground stays alive past the previous ~100ms exit (same `timeout` test)
- [x] Manual round-trip mail test: `tps mail send anvil "..."` → anvil agent receives → reply lands in `flint/new/` (~25s round-trip via wire)
- [x] `bun run build` clean
- [x] `bun run lint` clean (no new warnings introduced by these 6 lines)
- [ ] CI passes