### PR TITLE
fix: branch service routes incoming mail by body.to when local inbox exists

### DIFF
--- a/packages/cli/src/commands/branch.ts
+++ b/packages/cli/src/commands/branch.ts
@@ -7,7 +7,7 @@ import { listenForHost, listenForJoin } from "../utils/noise-ik-transport.js";
 import { listenForHostWs, listenForJoinWs } from "../utils/ws-noise-transport.js";
 import { MailDeliverBodySchema, MSG_MAIL_DELIVER, MSG_MAIL_ACK, MSG_HEARTBEAT, MSG_JOIN_COMPLETE, JoinCompleteBodySchema } from "../utils/wire-mail.js";
 import { startServiceProxies, type ServiceProxySet } from "../utils/service-proxy-branch.js";
-import { sendMessage } from "../utils/mail.js";
+import { sendMessage, inboxExists } from "../utils/mail.js";
 import { drainOutbox, queueOutboxMessage } from "../utils/outbox.js";
 import { clearBranchState, writeBranchState } from "../utils/connection-state.js";
 import { discoverManifests } from "../utils/manifest.js";
@@ -314,15 +314,18 @@ async function runStart(): Promise<void> {
         logLine("HANDLER", `Message ${body.id} dropped`);
         break;
       case "inbox":
-      default:
-        // Store under localAgentId (branch's own identity), not body.to.
-        // body.to may be a GAL logical name (e.g. "anvil") that differs from
-        // the branch's identity dir (e.g. "tps-anvil"). Preserving body.to
-        // in the message metadata keeps the original recipient visible.
-        try { sendMessage(localAgentId, body.content, body.from); } catch (e: any) {
+      default: {
+        // Route by body.to when the recipient has an inbox on this branch
+        // (multi-agent case: tps-anvil hosts both `anvil` and `anvil-2`).
+        // Fall back to localAgentId when body.to has no inbox here — that
+        // preserves the original behavior for the GAL-alias case where
+        // body.to is a logical name that doesn't match any local agent dir.
+        const recipient = inboxExists(body.to) ? body.to : localAgentId;
+        try { sendMessage(recipient, body.content, body.from); } catch (e: any) {
           logLine("WARN", `Mail write failed: ${e.message}`);
         }
         break;
+      }
     }
 
     await channel.send({ type: MSG_MAIL_ACK, seq: msg.seq, ts: new Date().toISOString(), body: { id: body.id, accepted: true } }).catch(() => {});

--- a/packages/cli/src/utils/mail.ts
+++ b/packages/cli/src/utils/mail.ts
@@ -56,6 +56,23 @@ export function getMailDir(): string {
   return dir;
 }
 
+/**
+ * Returns true if an inbox directory already exists for `agent` — without
+ * creating one. Use this when you need to choose a routing target between
+ * candidate recipients (e.g. branch service deciding whether to deliver to
+ * body.to or fall back to its own identity).
+ */
+export function inboxExists(agent: string): boolean {
+  try {
+    assertValidAgentId(agent);
+  } catch {
+    return false;
+  }
+  const branchMailRoot = join(process.env.HOME || homedir(), ".tps", "branch-office", agent, "mail");
+  if (existsSync(branchMailRoot)) return true;
+  return existsSync(join(getMailDir(), agent));
+}
+
 export function getInbox(agent: string): { root: string; tmp: string; fresh: string; cur: string; dlq: string } {
   assertValidAgentId(agent);
 

--- a/packages/cli/test/mail.test.ts
+++ b/packages/cli/test/mail.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, readdirSync, mkdirSync, writeFileSync } from "node
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
-import { checkMessages, getInbox, listMessages, sendMessage } from "../src/utils/mail.js";
+import { checkMessages, getInbox, inboxExists, listMessages, sendMessage } from "../src/utils/mail.js";
 
 const TPS_BIN = resolve(import.meta.dir, "../bin/tps.ts");
 
@@ -67,6 +67,25 @@ describe("mail utils", () => {
   test("rejects body over 64KB", () => {
     const huge = "a".repeat(70_000);
     expect(() => sendMessage("kern", huge, "anvil")).toThrow(/64KB/);
+  });
+
+  test("inboxExists is false until something writes to the inbox", () => {
+    expect(inboxExists("never-seen")).toBe(false);
+    sendMessage("never-seen", "hello", "anvil");
+    expect(inboxExists("never-seen")).toBe(true);
+  });
+
+  test("inboxExists does not create the inbox dir", () => {
+    expect(inboxExists("ghost")).toBe(false);
+    // Calling it again still returns false — no side effect.
+    expect(inboxExists("ghost")).toBe(false);
+    // listMessages on a never-created agent returns [] without crashing.
+    expect(listMessages("ghost")).toEqual([]);
+  });
+
+  test("inboxExists returns false for invalid ids without throwing", () => {
+    expect(inboxExists("../etc/passwd")).toBe(false);
+    expect(inboxExists("")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

When a branch hosts more than one agent, incoming wire mail should land in the recipient's inbox — not lumped into the branch's own identity dir.

Today: `branch.ts:runStart` always calls `sendMessage(localAgentId, ...)` for the inbox case. So on a tps-anvil branch hosting both \`anvil\` and \`anvil-2\`, every message ends up in \`~/.tps/mail/anvil/new/\`. The second agent's watcher never sees its mail.

After this PR: prefer \`body.to\` when an inbox already exists for it on this branch. Fall back to \`localAgentId\` when not — that preserves the original GAL-alias safety case (#240) where \`body.to\` is a logical name with no local dir.

## Why this matters

I hit this bringing Anvil-2 online tonight. Same gateway, second agent, separate Flair Agent record, openclaw \`bindings\` entry, dedicated \`anvil-2/new/\` mail dir watched by openclaw-tps-mail. All wired correctly — and every test mail still ended up in \`anvil/new/\` because the branch service didn't read \`body.to\`.

Discovered while debugging, fixing in source so the next person doesn't repeat it.

## Changes

- \`packages/cli/src/commands/branch.ts\` — at the \`inbox\` case, route by \`body.to\` when local inbox exists; else fall back.
- \`packages/cli/src/utils/mail.ts\` — new \`inboxExists(agent)\` helper. Non-creating existence check (since \`getInbox\` mkdirSyncs and would side-effect the comparison).
- \`packages/cli/test/mail.test.ts\` — covers the new helper, including the no-side-effect property and invalid-id tolerance.

## Test plan

- [x] \`bun test test/mail.test.ts\` — 16/16 pass (3 new)
- [x] \`bun test test/branch-mail-identity.test.ts test/mail.test.ts test/branch.test.ts\` — 27/27 pass
- [x] \`bun run build\` clean
- [ ] CI passes
- [ ] After merge: re-test multi-agent (\`tps mail send anvil-2 ...\`) on tps-anvil — file should land in anvil-2/new/, not anvil/new/

## Pairs with

This is half of the cross-host multi-agent fix. The other half lives in \`openclaw-tps-mail\` plugin (separate PR coming) — currently the plugin writes outbound replies to \`mail/<recipient>/new/\` locally instead of routing remote-recipient replies through \`outbox/new/\` for branch-service relay. Both fixes are needed for end-to-end multi-agent cross-host mail.