### PR TITLE
fix: openclaw-tps-mail routes cross-host replies through outbox (pairs with #266)

### DIFF
--- a/plugins/openclaw-tps-mail/src/index.ts
+++ b/plugins/openclaw-tps-mail/src/index.ts
@@ -155,6 +155,61 @@ function writeMailFile(mailDir: string, recipient: string, message: TpsMailBody)
 }
 
 /**
+ * Write to ~/.tps/outbox/new/ for cross-host delivery via the TPS branch
+ * service. The branch service drains this directory on each heartbeat and
+ * relays messages over the wire to the host, which dispatches to the
+ * recipient's actual host. Format matches packages/cli/src/utils/outbox.ts
+ * `OutboxMessage`.
+ */
+function writeOutboxFile(message: TpsMailBody): string {
+  const outboxNew = resolve(process.env.HOME ?? homedir(), ".tps", "outbox", "new");
+  mkdirSync(outboxNew, { recursive: true });
+  const tsSlug = message.timestamp.replace(/[:.]/g, "-");
+  const filename = `${tsSlug}-${message.id}.json`;
+  const target = resolve(outboxNew, filename);
+  writeFileSync(
+    target,
+    JSON.stringify(
+      {
+        id: message.id,
+        to: message.to,
+        from: message.from,
+        body: message.body,
+        timestamp: message.timestamp,
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  return target;
+}
+
+/**
+ * Decide where to write outbound mail.
+ * - Local recipient (bound to this gateway via `bindings`): write to the
+ *   recipient's local inbox so the watcher picks it up directly.
+ * - Remote recipient (no binding): write to ~/.tps/outbox/new/ so the
+ *   branch service relays it over the wire to the appropriate host.
+ *
+ * Without this split, replies addressed to off-host agents (the cross-host
+ * case) silently land in this host's local mail/<recipient>/new/ and
+ * never reach the actual recipient.
+ */
+function deliverOutboundMail(
+  cfg: any,
+  accountId: string,
+  mailDir: string,
+  message: TpsMailBody,
+): { path: string; route: "local" | "outbox" } {
+  const localAgents = findBoundAgents(cfg, accountId);
+  if (localAgents.includes(message.to)) {
+    return { path: writeMailFile(mailDir, message.to, message), route: "local" };
+  }
+  return { path: writeOutboxFile(message), route: "outbox" };
+}
+
+/**
  * Move a mail file from <inbox>/new/ to <inbox>/cur/ with the given state
  * patch applied (typically `ackedAt` on success or `nackedAt` on failure).
  *
@@ -272,12 +327,17 @@ const outbound: ChannelOutboundAdapter = {
       },
       deliveryAttempts: 0,
     };
-    const filePath = writeMailFile(account.mailDir, ctx.to, message);
+    const { path: filePath, route } = deliverOutboundMail(
+      ctx.cfg as any,
+      ctx.accountId ?? "default",
+      account.mailDir,
+      message,
+    );
     return {
       ok: true,
       id: message.id,
       externalId: message.id,
-      details: { path: filePath },
+      details: { path: filePath, route },
     } as any;
   },
 };
@@ -433,9 +493,14 @@ const gateway: ChannelGatewayAdapter<TpsMailAccount> = {
                 },
                 deliveryAttempts: 0,
               };
-              writeMailFile(account.mailDir, msg.from, reply);
+              const { route } = deliverOutboundMail(
+                cfg as any,
+                ctx.accountId ?? "default",
+                account.mailDir,
+                reply,
+              );
               log?.info?.(
-                `tps-mail: reply ${reply.id} from ${recipient} to ${msg.from} (via dispatcher)`,
+                `tps-mail: reply ${reply.id} from ${recipient} to ${msg.from} (via dispatcher, route=${route})`,
               );
             },
           },

--- a/plugins/openclaw-tps-mail/src/index.ts
+++ b/plugins/openclaw-tps-mail/src/index.ts
@@ -372,20 +372,20 @@ const gateway: ChannelGatewayAdapter<TpsMailAccount> = {
     );
 
     const watchers: FSWatcher[] = [];
+    // seenFiles dedupes inotify events (fs.watch can fire multiple times per
+    // write — see the debounce in the watcher callback). It is intentionally
+    // NOT pre-populated from the existing new/ snapshot at startup: any file
+    // already sitting in new/ when the gateway starts is mail that arrived
+    // while the gateway was down (or that a previous turn never ack'd) and
+    // MUST be processed on this startup, not silently swallowed.
+    //
+    // Replay safety comes from `moveToCur` after dispatch — successful turns
+    // ack and move the file to cur/, failed dispatches nack and also move to
+    // cur/, malformed files are moved to dlq/. None of these paths leave a
+    // file in new/, so re-processing the same id twice is impossible across
+    // restarts unless the gateway crashed mid-turn (acceptable: at-least-once
+    // delivery is the contract).
     const seenFiles = new Set<string>();
-
-    // Pre-populate seenFiles with existing entries in new/ so we don't replay
-    // mail from before plugin startup. This matches the behavior of the old
-    // tps mail watch CLI.
-    for (const agentId of boundAgents) {
-      const newDir = resolve(account.mailDir, agentId, "new");
-      if (!existsSync(newDir)) continue;
-      try {
-        for (const filename of readdirSync(newDir)) {
-          seenFiles.add(resolve(newDir, filename));
-        }
-      } catch { /* ignore */ }
-    }
 
     async function processNewFile(recipient: string, filePath: string): Promise<void> {
       if (seenFiles.has(filePath)) return;


### PR DESCRIPTION
## Summary

The plugin's outbound and dispatcher reply paths both write outbound mail via \`writeMailFile(mailDir, recipient, message)\` — which lands in **this host's** local \`mail/<recipient>/new/\` regardless of where the recipient actually lives. For same-gateway recipients that's correct. For off-host recipients (the cross-host case) the file is written locally and the actual recipient never sees it. Silent black hole.

Fix: route by recipient locality.

\`\`\`ts
function deliverOutboundMail(cfg, accountId, mailDir, message) {
  const localAgents = findBoundAgents(cfg, accountId);
  if (localAgents.includes(message.to)) {
    return { path: writeMailFile(...), route: "local" };
  }
  return { path: writeOutboxFile(message), route: "outbox" };
}
\`\`\`

\`writeOutboxFile\` writes the OutboxMessage shape that \`packages/cli/src/utils/outbox.ts\` defines, into \`~/.tps/outbox/new/\`. The TPS branch service drains that directory on each heartbeat and relays the message over the wire to the host, which dispatches to the recipient's host.

Both call sites updated:
- \`outbound.sendText\` (channel-send path used by tool-based replies)
- Dispatcher \`deliver\` callback (the path future agents will use)

The dispatcher log now includes \`route=local|outbox\` so the routing decision is visible in operations.

## Why this matters

Half of the cross-host multi-agent fix. The other half is tpsdev-ai/cli#266 (branch service routes by body.to when local inbox exists). Without both, multi-agent on a single branch is a one-way street — inbound reaches the right agent (#266) but their reply gets lost in the local filesystem (this PR).

Discovered tonight bringing Anvil-2 online. Anvil-2 processed mail correctly, replied via the dispatcher path — and the reply silently landed in \`anvil-host:/home/exedev/.tps/mail/flint/new/\` instead of rockit's flint inbox. Three minutes of "did the agent freeze?" before I traced the path.

## Routing decision tree (for reviewers)

| recipient bound to this gateway? | write target | branch service relays? |
|---|---|---|
| yes | \`mail/<recipient>/new/\` | no — local watcher picks it up |
| no  | \`outbox/new/\` | yes — sent over wire on next heartbeat |

The "bound" check uses the existing \`findBoundAgents(cfg, accountId)\` helper that the watcher already uses to decide which inboxes to watch. Single source of truth for \"agents on this gateway.\"

## Test plan

- [x] Pre-existing TS errors unchanged (module resolution + \`account: any\` — not introduced by this change).
- [ ] CI passes
- [ ] Manual after merge + deploy: \`tps mail send anvil-2 \"...\"\` from rockit → anvil-2 receives → reply lands in **rockit's** flint inbox (not anvil's local mail/flint/new).

## Pairs with

- tpsdev-ai/cli#266 — branch service body.to routing (inbound side)
- tpsdev-ai/cli#265 — bun event-loop keepalive (the daemon both fixes depend on staying alive)