### PR TITLE
fix: tps mail ack auto-purges cur/ to prevent quota accumulation (ops-xi76)

### DIFF
--- a/packages/cli/src/utils/mail.ts
+++ b/packages/cli/src/utils/mail.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -256,6 +256,8 @@ export function ackMessage(agent: string, id: string): MailMessage | null {
   delete msg.checkedOutBy;
   delete msg.retryAfter;
   writeMessageFile(path, msg);
+  // Remove the file from cur/ now that it's acked — audit trail is in log/
+  try { unlinkSync(path); } catch { /* best effort — don't fail ack if cleanup fails */ }
   return msg;
 }
 

--- a/packages/cli/test/mail.test.ts
+++ b/packages/cli/test/mail.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, readdirSync, mkdirSync, writeFileSync } from "node
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
-import { checkMessages, getInbox, inboxExists, listMessages, sendMessage } from "../src/utils/mail.js";
+import { checkMessages, getInbox, inboxExists, listMessages, sendMessage, ackMessage, countInboxMessages } from "../src/utils/mail.js";
 
 const TPS_BIN = resolve(import.meta.dir, "../bin/tps.ts");
 
@@ -86,6 +86,46 @@ describe("mail utils", () => {
   test("inboxExists returns false for invalid ids without throwing", () => {
     expect(inboxExists("../etc/passwd")).toBe(false);
     expect(inboxExists("")).toBe(false);
+  });
+
+  test("ackMessage removes the file from cur/", () => {
+    const m = sendMessage("kern", "ack-test", "anvil");
+    expect(m.to).toBe("kern");
+    const inbox = getInbox("kern");
+
+    // Move from new -> cur via check
+    checkMessages("kern");
+    expect(readdirSync(inbox.fresh).filter((f) => f.endsWith(".json")).length).toBe(0);
+
+    const curFilesBefore = readdirSync(inbox.cur).filter((f) => f.endsWith(".json"));
+    expect(curFilesBefore.length).toBe(1);
+
+    // Ack removes it
+    const acked = ackMessage("kern", m.id);
+    expect(acked).not.toBeNull();
+
+    const curFilesAfter = readdirSync(inbox.cur).filter((f) => f.endsWith(".json"));
+    expect(curFilesAfter.length).toBe(0);
+  });
+
+  test("countInboxMessages drops after ack", () => {
+    // Send 5 messages
+    for (let i = 0; i < 5; i++) {
+      sendMessage("kern", `msg-${i}`, "anvil");
+    }
+    expect(countInboxMessages("kern")).toBe(5);
+
+    // Check all (moves new -> cur)
+    const msgs = checkMessages("kern");
+    expect(msgs.length).toBe(5);
+    expect(countInboxMessages("kern")).toBe(5);
+
+    // Ack 3
+    ackMessage("kern", msgs[0]!.id);
+    ackMessage("kern", msgs[1]!.id);
+    ackMessage("kern", msgs[2]!.id);
+
+    expect(countInboxMessages("kern")).toBe(2);
   });
 });
 


### PR DESCRIPTION
## ops-xi76: tps mail ack auto-purges cur/

### Root cause
`tps mail ack` marked messages read but left them in `cur/` indefinitely. `countInboxMessages` sums `new/ + cur/`, so acked messages counted against the `MAX_INBOX_MESSAGES = 100` quota forever. This caused the recurring inbox-cap incidents on rockit (2 manual drains in 12 hours, 2026-04-27/28).

### Fix
`ackMessage` now calls `unlinkSync(path)` after writing the ack metadata to the file. The audit trail is already in `log/archive.db` (via `logEvent`), so `cur/` doesn't need to serve as a parallel archive.

### Tests added
1. **`ackMessage removes the file from cur/`** — sends message, checks it (moves new→cur), acks it, asserts cur/ is empty.
2. **`countInboxMessages drops after ack`** — sends 5, checks all (count=5), acks 3, asserts count=2.

### Existing behavior preserved
- `tps mail check` semantics unchanged
- `tps mail log` still works (reads from archive.db, not cur/)
- `tps mail list` still works (reads from cur/ before ack, from listMessages which includes fresh+cur+dlq)
- `tps mail gc` still handles DLQ and hard-TTL recovery; acked cur/ files are already gone