### PR TITLE
fix(ci): refactor github.* expressions to env: blocks to fix Semgrep SAST (ops-q2hs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,21 @@ jobs:
         with:
           fetch-depth: 0
       - name: Verify tag is on main
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
-            echo "❌ Tag ${{ github.ref_name }} points to a commit not on main."
+          if ! git merge-base --is-ancestor $GITHUB_SHA origin/main; then
+            echo "❌ Tag $GITHUB_REF_NAME points to a commit not on main."
             echo "   Release tags must be on the main branch."
             echo "   Push the version bump via PR first, then tag."
             exit 1
           fi
       - name: Verify package versions match tag
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          TAG_VERSION="${{ github.ref_name }}"
+          TAG_VERSION="$GITHUB_REF_NAME"
           TAG_VERSION="${TAG_VERSION#v}"
           PKG_VERSION=$(node -p "require('./packages/cli/package.json').version")
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
@@ -151,8 +156,11 @@ jobs:
       - name: Build agent package
         run: bun run --filter @tpsdev-ai/agent build
       - name: Publish agent package
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          VERSION="${{ github.ref_name }}"
+          VERSION="$GITHUB_REF_NAME"
           VERSION="${VERSION#v}"
           npm publish --access public --workspace @tpsdev-ai/agent || {
             if npm view "@tpsdev-ai/agent@$VERSION" version 2>/dev/null; then
@@ -161,11 +169,12 @@ jobs:
               echo "❌ Failed to publish @tpsdev-ai/agent" && exit 1
             fi
           }
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish platform packages
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          VERSION="${{ github.ref_name }}"
+          VERSION="$GITHUB_REF_NAME"
           VERSION="${VERSION#v}"
           for pkg in cli-darwin-arm64 cli-darwin-x64 cli-linux-arm64 cli-linux-x64; do
             npm publish --access public --workspace "@tpsdev-ai/$pkg" || {
@@ -176,11 +185,12 @@ jobs:
               fi
             }
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish meta package
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          VERSION="${{ github.ref_name }}"
+          VERSION="$GITHUB_REF_NAME"
           VERSION="${VERSION#v}"
           npm publish --access public --workspace @tpsdev-ai/cli || {
             if npm view "@tpsdev-ai/cli@$VERSION" version 2>/dev/null; then
@@ -189,8 +199,6 @@ jobs:
               exit 1
             fi
           }
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   github-release:
     name: GitHub release checksums


### PR DESCRIPTION
## ops-q2hs: Fix Semgrep SAST shell-injection findings in release.yml

Refactored all `${{ github.* }}` expressions from `run:` blocks into `env:` blocks using the standard Semgrep-recommended pattern.

### Changes
All 5 Semgrep findings fixed:

1. `Verify tag is on main`: `${{ github.sha }}` → `$GITHUB_SHA`, `${{ github.ref_name }}` → `$GITHUB_REF_NAME`
2. `Verify package versions match tag`: `${{ github.ref_name }}` → `$GITHUB_REF_NAME`
3. `Publish agent package`: `${{ github.ref_name }}` → `$GITHUB_REF_NAME`
4. `Publish platform packages`: `${{ github.ref_name }}` → `$GITHUB_REF_NAME`
5. `Publish meta package`: `${{ github.ref_name }}` → `$GITHUB_REF_NAME`

No behavioral change — env var references are equivalent at runtime.