### PR TITLE
feat(branch): tps branch init --agent <id> persists agentId in conf (ops-hs19)

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -843,7 +843,7 @@ async function main() {
       const action = rest[0] as "init" | "start" | "stop" | "status" | "log" | undefined;
       const valid = ["init", "start", "stop", "status", "log"];
       if (!action || !valid.includes(action)) {
-        console.error("Usage:\n  tps branch init [--listen <port>] [--host <hostname>] [--transport ws|tcp]\n  tps branch start\n  tps branch stop\n  tps branch status\n  tps branch log [--lines N] [--follow]");
+        console.error("Usage:\n  tps branch init [--listen <port>] [--host <hostname>] [--transport ws|tcp] [--agent <id>]\n  tps branch start\n  tps branch stop\n  tps branch status\n  tps branch log [--lines N] [--follow]");
         process.exit(1);
       }
       const { runBranch } = await import("../src/commands/branch.js");
@@ -852,6 +852,7 @@ async function main() {
         port: typeof cli.flags.listen === "number" ? Number(cli.flags.listen) : undefined,
         host: cli.flags.host,
         transport: cli.flags.transport === "tcp" ? "tcp" : cli.flags.transport === "ws" ? "ws" : undefined,
+        agent: cli.flags.agent,
         force: cli.flags.force,
         lines: typeof cli.flags.lines === "number" ? Number(cli.flags.lines) : undefined,
         follow: !!cli.flags.follow,

--- a/packages/cli/src/commands/branch.ts
+++ b/packages/cli/src/commands/branch.ts
@@ -21,6 +21,7 @@ export interface BranchArgs {
   port?: number;
   host?: string;
   transport?: "ws" | "tcp";
+  agent?: string;
   force?: boolean;
   lines?: number;
   follow?: boolean;
@@ -63,7 +64,7 @@ function processAlive(pid: number): boolean {
   }
 }
 
-function writeBranchConf(port: number, host: string, transport: "ws" | "tcp", agentsDir?: string): void {
+export function writeBranchConf(port: number, host: string, transport: "ws" | "tcp", agentsDir?: string, agentId?: string): void {
   writeFileSync(
     confPath(),
     JSON.stringify(
@@ -72,6 +73,7 @@ function writeBranchConf(port: number, host: string, transport: "ws" | "tcp", ag
         host,
         transport,
         agentsDir,
+        agentId,
         createdAt: new Date().toISOString(),
       },
       null,
@@ -81,7 +83,7 @@ function writeBranchConf(port: number, host: string, transport: "ws" | "tcp", ag
   );
 }
 
-function readBranchConf(): { port: number; host: string; transport: "ws" | "tcp"; agentsDir?: string } {
+function readBranchConf(): { port: number; host: string; transport: "ws" | "tcp"; agentsDir?: string; agentId?: string } {
   const p = confPath();
   if (!existsSync(p)) throw new Error("branch.conf.json not found. Run `tps branch init` first.");
   const raw = JSON.parse(readFileSync(p, "utf-8"));
@@ -90,7 +92,8 @@ function readBranchConf(): { port: number; host: string; transport: "ws" | "tcp"
     port: Number(raw.port),
     host: String(raw.host || ""),
     transport: t,
-    agentsDir: raw.agentsDir ? String(raw.agentsDir) : undefined
+    agentsDir: raw.agentsDir ? String(raw.agentsDir) : undefined,
+    agentId: raw.agentId ? String(raw.agentId) : undefined
   };
 }
 
@@ -125,7 +128,11 @@ async function runInit(args: BranchArgs): Promise<void> {
   const port = args.port ?? 6458;
   const advertiseHost = args.host ?? hostname();
   const transport = args.transport ?? "ws";
-  writeBranchConf(port, advertiseHost, transport, undefined);
+  // agentId resolves the maildir for branch-delivered messages. Default to
+  // the value at runBranch start time (TPS_AGENT_ID env → conf.agentId →
+  // hostname). Persisting at init time lets `tps branch start` pick it up
+  // without re-setting TPS_AGENT_ID in the environment.
+  writeBranchConf(port, advertiseHost, transport, undefined, args.agent);
 
   const pubkeyB64 = Buffer.from(kp.encryption.publicKey).toString("base64url");
   const sigPubkeyB64 = Buffer.from(kp.signing.publicKey).toString("base64url");

--- a/packages/cli/test/branch.test.ts
+++ b/packages/cli/test/branch.test.ts
@@ -2,7 +2,8 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { buildJoinToken, isAlreadyJoined } from "../src/commands/branch.js";
+import { readFileSync } from "node:fs";
+import { buildJoinToken, isAlreadyJoined, writeBranchConf } from "../src/commands/branch.js";
 
 describe("tps branch init", () => {
   let tmpDir: string;
@@ -56,6 +57,32 @@ describe("tps branch init", () => {
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "host.json"), JSON.stringify({ hostId: "existing" }));
     expect(isAlreadyJoined(dir)).toBe(true);
+  });
+
+  test("writeBranchConf persists agentId when --agent supplied (ops-hs19)", () => {
+    process.env.TPS_ROOT = tmpDir;
+    try {
+      writeBranchConf(33744, "localhost", "ws", undefined, "reed");
+      const conf = JSON.parse(readFileSync(join(tmpDir, "branch.conf.json"), "utf-8"));
+      expect(conf.agentId).toBe("reed");
+      expect(conf.port).toBe(33744);
+      expect(conf.host).toBe("localhost");
+      expect(conf.transport).toBe("ws");
+    } finally {
+      delete process.env.TPS_ROOT;
+    }
+  });
+
+  test("writeBranchConf omits agentId when not supplied (back-compat)", () => {
+    process.env.TPS_ROOT = tmpDir;
+    try {
+      writeBranchConf(6458, "tps-host", "ws");
+      const conf = JSON.parse(readFileSync(join(tmpDir, "branch.conf.json"), "utf-8"));
+      expect(conf.agentId).toBeUndefined();
+      expect(conf.port).toBe(6458);
+    } finally {
+      delete process.env.TPS_ROOT;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a `--agent <id>` flag to `tps branch init` that persists the local agent identity to `branch.conf.json`. Closes the maildir naming inconsistency surfaced during Reed Phase 2 dogfood: without an explicit agentId, the branch daemon's mail handler falls back to `hostname()` for the first message, then routes to `body.to` for subsequent messages once the maildir exists — producing two parallel maildirs for the same logical agent.

## Problem (from live tps-reed dogfood)

Branch daemon's incoming-mail handler at `branch.ts:323`:
```ts
const recipient = inboxExists(body.to) ? body.to : localAgentId;
```

When `localAgentId` defaults to `hostname()` (no TPS_AGENT_ID env, no conf.agentId), the first message routes to `~/.tps/mail/<hostname>/` as fallback. Once any local code creates `~/.tps/mail/<body.to>/` (e.g., the user runs `tps mail check reed`), subsequent messages route there instead. Mail splits across two maildirs; watchers consuming one path miss messages addressed to the other.

Repro on tps-reed 2026-05-16:
- First PING `body.to=reed` → `~/.tps/mail/tps-reed/new/` (fallback)
- Subsequent PING `body.to=reed` → `~/.tps/mail/reed/new/`

Filed as **ops-hs19**.

## Fix

`tps branch init --agent <id>` writes `{agentId: "<id>"}` to `branch.conf.json`. The daemon's `getLocalAgentId()` already reads conf.agentId at position 2 in its precedence chain (env → conf → hostname), so the routing decision is now consistent from message #1: maildir is `~/.tps/mail/<agentId>/` always.

No daemon-side code change required. The fix is purely on the init/persist path.

## Tests

- New: `writeBranchConf persists agentId when --agent supplied (ops-hs19)` — verifies the conf write
- New: `writeBranchConf omits agentId when not supplied (back-compat)` — verifies existing zero-flag behavior is preserved
- Existing 5 branch tests + 5 outbox tests pass (13/13 total)

## Migration for existing branch offices

```sh
# On the VM, one-time:
jq '. + {agentId: "<your-agent>"}' ~/.tps/branch.conf.json > /tmp/c.json \
  && mv /tmp/c.json ~/.tps/branch.conf.json
tps branch stop && tps branch start
```

Applied on tps-reed live during testing; PING round-trip verified mail lands at `/reed/` consistently from message #1.

## Updated provisioning recipe

The branch-office provisioning flow (memory: `reference_branch_office_provisioning_recipe.md`) gets one more flag on the `tps branch init` line. Documenting the new shape:

```sh
# Old (post-init manual conf-edit):
tps branch init --listen 33744 --host localhost --transport ws

# New:
tps branch init --listen 33744 --host localhost --transport ws --agent <your-agent>
```

## Test plan

- [x] `bun test test/branch.test.ts test/outbox.test.ts` — 13 pass
- [x] `bun run build` — dist regenerated
- [x] Live verification on tps-reed (manual conf edit equivalent to --agent flag) — PING-PONG verified maildir consistency
- [ ] K&S ensemble review (will dispatch via TPS mail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)