### PR TITLE
fix(mail): guard sendMessage against leaking into production maildir

### DIFF
--- a/packages/cli/src/utils/mail.ts
+++ b/packages/cli/src/utils/mail.ts
@@ -164,6 +164,18 @@ export function sendMessage(to: string, body: string, from?: string): MailMessag
   assertValidAgentId(sender);
   assertValidBody(body);
 
+  // Guard: when running in test mode or when the caller has explicitly
+  // opted in, refuse to write to the default ~/.tps/mail/ directory
+  // unless TPS_MAIL_DIR is set. This prevents tests from accidentally
+  // spraying messages into the real production maildir (e.g. when
+  // imported directly without beforeEach setting TPS_MAIL_DIR to a temp dir).
+  if ((process.env.NODE_ENV === "test" || process.env.TPS_MAIL_REQUIRE_EXPLICIT_DIR) && !process.env.TPS_MAIL_DIR) {
+    throw new Error(
+      "TPS_MAIL_DIR must be set explicitly in test mode. " +
+      "Refusing to write to the default production maildir.",
+    );
+  }
+
   const inbox = getInbox(to);
   const quotaCount = countInboxMessages(to);
   if (quotaCount >= MAX_INBOX_MESSAGES) {


### PR DESCRIPTION
## Summary

Cherry-pick of Anvil's mail-guard fix from #287, isolated as a single commit on a clean branch off current main. #287 had two unrelated commits ahead of this one (skill add-pack + sherlock fix) that are duplicates of already-merged work — closing that PR in favor of this clean one.

## What it does

`sendMessage()` in `packages/cli/src/utils/mail.ts` defaults to `~/.tps/mail/` when `TPS_MAIL_DIR` is unset. When tests import `sendMessage` outside a test framework that sets `TPS_MAIL_DIR` (e.g., direct module import in a tooling context), messages silently land in the real production maildir.

This caused 188 phantom messages (`msg-0` … `msg-99+`) to appear in a production inbox today, all timestamped within sub-second bursts, from=anvil, X-TPS-Trust=user.

## Fix

Adds a guard at the top of `sendMessage()`: if `NODE_ENV=test` OR `TPS_MAIL_REQUIRE_EXPLICIT_DIR` is set AND `TPS_MAIL_DIR` is unset, throw with an explicit error. Tests that already set `TPS_MAIL_DIR` in their `beforeEach` are unaffected.

12 lines added in `mail.ts`. No test changes (existing 6 pre-existing test failures in `mail.test.ts` are separate — needs follow-up; not in scope here).

## Why this branch, not #287

#287 contained three commits, two of which duplicate already-merged work (cli#278 skill-add-pack + sherlock shell-injection fix). This branch is the single real new commit, cleanly off current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)