### PR TITLE
fix(branch+relay): honest NACK on inbox-full write failure (P1)

### DIFF
--- a/packages/cli/src/commands/branch.ts
+++ b/packages/cli/src/commands/branch.ts
@@ -300,6 +300,12 @@ async function runStart(): Promise<void> {
     }
     const body = parsed.data;
 
+    // Track delivery failure so the ACK reflects actual write success/failure.
+    // Without this, an "Inbox full" or similar write error would silently turn
+    // into accepted=true and the host's deliverToRemoteBranch would log
+    // "Mail delivered" while the message was actually dropped.
+    let deliveryError: string | null = null;
+
     const action = await runHandlerPipeline(
       { id: body.id, from: body.from, to: body.to, body: body.content, timestamp: body.timestamp },
       manifests,
@@ -328,14 +334,28 @@ async function runStart(): Promise<void> {
         // preserves the original behavior for the GAL-alias case where
         // body.to is a logical name that doesn't match any local agent dir.
         const recipient = inboxExists(body.to) ? body.to : localAgentId;
-        try { sendMessage(recipient, body.content, body.from); } catch (e: any) {
-          logLine("WARN", `Mail write failed: ${e.message}`);
+        try {
+          sendMessage(recipient, body.content, body.from);
+        } catch (e: any) {
+          // Honest NACK: an "Inbox full" or other write failure must NOT be
+          // ACKed as accepted=true. Silent drops here strand entire dispatches
+          // because the host's deliverToRemoteBranch only checks the ACK.
+          deliveryError = e?.message || "Mail write failed";
+          logLine("WARN", `Mail write failed: ${deliveryError}`);
         }
         break;
       }
     }
 
-    await channel.send({ type: MSG_MAIL_ACK, seq: msg.seq, ts: new Date().toISOString(), body: { id: body.id, accepted: true } }).catch(() => {});
+    const ackAccepted = deliveryError === null;
+    await channel.send({
+      type: MSG_MAIL_ACK,
+      seq: msg.seq,
+      ts: new Date().toISOString(),
+      body: ackAccepted
+        ? { id: body.id, accepted: true }
+        : { id: body.id, accepted: false, error: deliveryError },
+    }).catch(() => {});
 
     for (const item of drainOutbox()) {
       await channel.send({

--- a/packages/cli/src/commands/branch.ts
+++ b/packages/cli/src/commands/branch.ts
@@ -55,6 +55,21 @@ function logLine(event: string, msg: string): void {
   appendFileSync(logPath(), `[${new Date().toISOString()}] ${event}: ${msg}\n`, "utf-8");
 }
 
+/**
+ * Map a raw sendMessage error to a sanitized category safe to send on-wire.
+ * Raw errors can include filesystem paths or internal state (Sherlock #294);
+ * the host only needs to know the category to surface a useful failure.
+ */
+function sanitizeDeliveryError(raw: string): string {
+  const r = raw.toLowerCase();
+  if (r.includes("inbox full")) return "inbox-full";
+  if (r.includes("eacces") || r.includes("eperm") || r.includes("permission denied")) return "permission-denied";
+  if (r.includes("enospc") || r.includes("no space")) return "disk-full";
+  if (r.includes("enoent") || r.includes("no such")) return "path-missing";
+  if (r.includes("invalid")) return "invalid-input";
+  return "write-failed";
+}
+
 function processAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -340,8 +355,12 @@ async function runStart(): Promise<void> {
           // Honest NACK: an "Inbox full" or other write failure must NOT be
           // ACKed as accepted=true. Silent drops here strand entire dispatches
           // because the host's deliverToRemoteBranch only checks the ACK.
-          deliveryError = e?.message || "Mail write failed";
-          logLine("WARN", `Mail write failed: ${deliveryError}`);
+          // Log the raw error locally, but send only a sanitized category
+          // to the host (Sherlock #294: raw error messages can include
+          // filesystem paths or internal state — leak surface to remote).
+          const rawError = e?.message || "Mail write failed";
+          logLine("WARN", `Mail write failed: ${rawError}`);
+          deliveryError = sanitizeDeliveryError(rawError);
         }
         break;
       }

--- a/packages/cli/src/utils/relay.ts
+++ b/packages/cli/src/utils/relay.ts
@@ -398,7 +398,15 @@ export async function deliverToRemoteBranch(
         if (msg.type === MSG_MAIL_ACK && (msg.body as any)?.id === msgId) {
           clearTimeout(timeout);
           channel.offMessage(handler);
-          resolve();
+          // Honor the branch's honest ACK: accepted:false means the write
+          // failed (inbox full, mode error, etc). Surface as a real delivery
+          // error rather than treating any ACK as success.
+          const ackBody = msg.body as any;
+          if (ackBody?.accepted === false) {
+            reject(new Error(`Branch refused delivery: ${ackBody?.error ?? "unknown reason"}`));
+          } else {
+            resolve();
+          }
         }
       };
       channel.onMessage(handler);


### PR DESCRIPTION
## Summary

P1 reliability fix surfaced by tonight's S5 dispatch stall.

**Bug:** Branch daemon's `MSG_MAIL_DELIVER` handler sent `MSG_MAIL_ACK` with `accepted: true` regardless of whether the underlying `sendMessage` write actually succeeded. The host's `deliverToRemoteBranch` only checks that an ACK arrives — not whether it claims success — so the host logged "Mail delivered to remote branch" while the message was dropped on the floor.

**Live evidence (2026-05-19 ~04:00-05:00Z):** My cred-substrate-S5 dispatch to Anvil silently failed when his `cur/` filled to `MAX_INBOX_MESSAGES=100`. The branch daemon log shows the smoking gun:

```
[2026-05-19T04:52:13.339Z] WARN: Mail write failed: Inbox full
[2026-05-19T04:52:13.339Z] MAIL: Received message for anvil (id: a50b548c-...)
```

The ACK had already flown by then. `tps mail send anvil` returned "Mail delivered" in 0.47s. Anvil never saw it. Took an hour to diagnose because every layer reported success.

## Fix (two-sided)

**`packages/cli/src/commands/branch.ts` (onMessage handler):**
- Track `deliveryError: string | null` at the top of the handler
- Set it inside the inbox-case `sendMessage` catch with the error message
- Build the ACK body conditionally: `accepted: true` when null, otherwise `{ accepted: false, error: deliveryError }`

**`packages/cli/src/utils/relay.ts` (`deliverToRemoteBranch` ACK handler):**
- Check `ackBody?.accepted === false` in the ack message
- If false, reject the acked promise with `Branch refused delivery: <reason>` so the host's mail-send raises rather than logging fake success

## Result

`tps mail send` now actually fails loud when the recipient's inbox is full (or any other write error). The host gets a real error instead of phantom success. The structural failure mode that stranded 10+ hours of S5 work is closed at the protocol layer.

The auxiliary fix — agent inbox auto-drain so we don't hit the cap silently in the first place — is its own P1 bead, separate work.

## Test plan

- [x] `bun run build` clean
- [x] Existing branch-mail-identity + branch-handler-wiring tests still pass (7/7)
- [ ] **No unit test added intentionally.** The change is localized, the protocol contract is small, and the live-burn motivation is fresh. K&S can ask for one if they want.
- [ ] Live verification will be: re-fill Anvil's inbox to cap, send a test message, verify `tps mail send` raises with the error reason. Will run after K&S approval before merge.

## Related

- P1 bead filed 2026-05-19 04:55Z
- Paired bead: agent inbox auto-drain (not addressed here — separate fix)
- Diagnosed during cred substrate S5 dispatch stall

🤖 Generated with [Claude Code](https://claude.com/claude-code)