### PR TITLE
fix(mail): inbox cap counts new/ only + auto-archive old cur entries (P1)

### DIFF
--- a/packages/cli/src/utils/mail.ts
+++ b/packages/cli/src/utils/mail.ts
@@ -261,7 +261,14 @@ export function checkMessages(agent: string, checkedOutBy = agent): MailMessage[
   // Opportunistic cur/ archive — keeps the processed tail from accumulating
   // indefinitely. Safe to no-op when there's nothing old; cost is one stat()
   // per cur entry, capped at the directory size.
-  try { archiveOldCur(agent); } catch { /* non-fatal */ }
+  try {
+    archiveOldCur(agent);
+  } catch (e: any) {
+    // Non-fatal: archive failure must never block mail processing. Log so
+    // operators can see ENOSPC, permissions, or other persistent issues
+    // rather than silently letting cur/ grow forever. (K&S #295 follow-up.)
+    console.warn(`[mail] archiveOldCur(${agent}) failed: ${e?.message ?? e}`);
+  }
 
   const messages: MailMessage[] = [];
   const nowIso = new Date().toISOString();

--- a/packages/cli/src/utils/mail.ts
+++ b/packages/cli/src/utils/mail.ts
@@ -152,10 +152,57 @@ function messagePathById(agent: string, id: string): string | null {
   return null;
 }
 
+/**
+ * Count of UNPROCESSED inbox messages — files in new/.
+ *
+ * The MAX_INBOX_MESSAGES cap is back-pressure for "agent isn't processing,"
+ * not "agent ran for too long." Previously this counted new+cur, which meant
+ * a busy agent's processed-but-not-archived mail would silently bounce
+ * incoming dispatches. Anvil hit this 2026-05-19 with 100 cur/ entries dating
+ * back to May 4 — fresh dispatches NACK'd with "Inbox full" while his
+ * processed mail sat there. Pair with archiveOldCur() for cur hygiene.
+ */
 export function countInboxMessages(agent: string): number {
   const inbox = getInbox(agent);
-  return readdirSync(inbox.fresh).filter((f) => f.endsWith(".json")).length +
-    readdirSync(inbox.cur).filter((f) => f.endsWith(".json")).length;
+  return readdirSync(inbox.fresh).filter((f) => f.endsWith(".json")).length;
+}
+
+/**
+ * Archive cur/ messages older than maxAgeDays to archive/YYYY-MM/.
+ *
+ * Returns the count moved. Idempotent and non-failing — corrupt or unreadable
+ * files are skipped without blocking the others. Called opportunistically
+ * from mail check / mail watch so the cap doesn't drift back into the
+ * combined-count failure mode if a future change re-introduces it.
+ *
+ * The 30-day default is conservative: agents that ack mail are essentially
+ * done with it, and the audit log + git history are the durable record. cur/
+ * just holds the "processed but not yet GC'd" tail.
+ */
+export function archiveOldCur(agent: string, maxAgeDays = 30): number {
+  const inbox = getInbox(agent);
+  if (!existsSync(inbox.cur)) return 0;
+  const cutoffMs = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+  const archiveRoot = join(inbox.root, "archive");
+  let moved = 0;
+  for (const file of readdirSync(inbox.cur).filter((f) => f.endsWith(".json"))) {
+    const src = join(inbox.cur, file);
+    try {
+      const st = statSync(src);
+      // Use mtime as the archive boundary — covers both naturally-old files
+      // and ones manually touched. Most cur/ entries are written-once when
+      // ack'd, so mtime ≈ when the agent processed them.
+      if (st.mtimeMs > cutoffMs) continue;
+      const ts = new Date(st.mtimeMs);
+      const monthDir = join(archiveRoot, `${ts.getUTCFullYear()}-${String(ts.getUTCMonth() + 1).padStart(2, "0")}`);
+      mkdirSync(monthDir, { recursive: true });
+      renameSync(src, join(monthDir, file));
+      moved++;
+    } catch {
+      // Skip on stat/rename failure — non-fatal; next call retries.
+    }
+  }
+  return moved;
 }
 
 export function sendMessage(to: string, body: string, from?: string): MailMessage & { filePath: string } {
@@ -210,6 +257,12 @@ export function checkMessages(agent: string, checkedOutBy = agent): MailMessage[
   assertValidAgentId(agent);
   assertValidAgentId(checkedOutBy);
   const inbox = getInbox(agent);
+
+  // Opportunistic cur/ archive — keeps the processed tail from accumulating
+  // indefinitely. Safe to no-op when there's nothing old; cost is one stat()
+  // per cur entry, capped at the directory size.
+  try { archiveOldCur(agent); } catch { /* non-fatal */ }
+
   const messages: MailMessage[] = [];
   const nowIso = new Date().toISOString();
   const nowMs = Date.now();

--- a/packages/cli/test/mail.test.ts
+++ b/packages/cli/test/mail.test.ts
@@ -9,9 +9,15 @@ const TPS_BIN = resolve(import.meta.dir, "../bin/tps.ts");
 
 describe("mail utils", () => {
   let tempRoot: string;
+  let savedHome: string | undefined;
 
   beforeEach(() => {
     tempRoot = mkdtempSync(join(tmpdir(), "tps-mail-test-"));
+    // Override HOME alongside TPS_MAIL_DIR — getInbox() prefers
+    // ~/.tps/branch-office/<agent>/mail when it exists, which would
+    // otherwise leak the test into the real on-host kern/anvil inboxes.
+    savedHome = process.env.HOME;
+    process.env.HOME = tempRoot;
     process.env.TPS_MAIL_DIR = join(tempRoot, "mail");
     process.env.TPS_AGENT_ID = "anvil";
   });
@@ -19,6 +25,8 @@ describe("mail utils", () => {
   afterEach(() => {
     delete process.env.TPS_MAIL_DIR;
     delete process.env.TPS_AGENT_ID;
+    if (savedHome !== undefined) process.env.HOME = savedHome;
+    else delete process.env.HOME;
     rmSync(tempRoot, { recursive: true, force: true });
   });
 
@@ -108,24 +116,94 @@ describe("mail utils", () => {
     expect(curFilesAfter.length).toBe(0);
   });
 
-  test("countInboxMessages drops after ack", () => {
-    // Send 5 messages
+  test("countInboxMessages counts new/ only — drops after check (semantic change 2026-05-19)", () => {
+    // Previously this counted new+cur, which caused Anvil to bounce fresh
+    // dispatches once his cur/ filled to 100 with processed-but-not-archived
+    // mail. New semantic: cap is back-pressure for "agent isn't processing,"
+    // so checkMessages (new -> cur) should drop the count to zero.
     for (let i = 0; i < 5; i++) {
       sendMessage("kern", `msg-${i}`, "anvil");
     }
     expect(countInboxMessages("kern")).toBe(5);
 
-    // Check all (moves new -> cur)
+    // Check all (moves new -> cur). With new semantic, count drops to 0.
     const msgs = checkMessages("kern");
     expect(msgs.length).toBe(5);
-    expect(countInboxMessages("kern")).toBe(5);
+    expect(countInboxMessages("kern")).toBe(0);
 
-    // Ack 3
+    // Ack doesn't change the count further (we're already at 0).
     ackMessage("kern", msgs[0]!.id);
-    ackMessage("kern", msgs[1]!.id);
-    ackMessage("kern", msgs[2]!.id);
+    expect(countInboxMessages("kern")).toBe(0);
+  });
 
-    expect(countInboxMessages("kern")).toBe(2);
+  test("100 messages in cur does NOT block new sends (Anvil 2026-05-19 regression)", async () => {
+    // Anvil's bug: cur/ filled to 100 with old processed mail; fresh
+    // dispatches NACK'd with "Inbox full" silently. Reproduce by stuffing
+    // cur/ then verifying a send still succeeds.
+    const inbox = getInbox("kern");
+    const { writeFileSync, mkdirSync } = await import("node:fs");
+    mkdirSync(inbox.cur, { recursive: true });
+    for (let i = 0; i < 100; i++) {
+      writeFileSync(
+        join(inbox.cur, `2026-05-04-old-${i}.json`),
+        JSON.stringify({ id: `old-${i}`, from: "anvil", to: "kern", body: "old", timestamp: "2026-05-04T00:00:00Z" }),
+      );
+    }
+    // 100 in cur, 0 in new. Should NOT throw.
+    expect(() => sendMessage("kern", "fresh dispatch", "anvil")).not.toThrow();
+  });
+
+  test("archiveOldCur moves only entries older than maxAgeDays", async () => {
+    const { archiveOldCur, getInbox } = await import("../src/utils/mail.js");
+    const inbox = getInbox("kern");
+    const { writeFileSync, mkdirSync, utimesSync, existsSync, readdirSync } = await import("node:fs");
+    mkdirSync(inbox.cur, { recursive: true });
+
+    // Write 3 entries with backdated mtimes — only one (60d old) should archive
+    // under default maxAgeDays=30.
+    const old60 = join(inbox.cur, "old-60d.json");
+    const old10 = join(inbox.cur, "old-10d.json");
+    const recent = join(inbox.cur, "recent.json");
+    for (const p of [old60, old10, recent]) {
+      writeFileSync(p, JSON.stringify({ id: "x", from: "anvil", to: "kern", body: "x", timestamp: new Date().toISOString() }));
+    }
+    const now = Date.now();
+    utimesSync(old60, new Date(now - 60 * 86_400_000), new Date(now - 60 * 86_400_000));
+    utimesSync(old10, new Date(now - 10 * 86_400_000), new Date(now - 10 * 86_400_000));
+
+    const moved = archiveOldCur("kern", 30);
+    expect(moved).toBe(1);
+
+    const curRemaining = readdirSync(inbox.cur).filter((f) => f.endsWith(".json"));
+    expect(curRemaining).toContain("old-10d.json");
+    expect(curRemaining).toContain("recent.json");
+    expect(curRemaining).not.toContain("old-60d.json");
+
+    // Archive structure: ~/.tps/mail/<agent>/archive/YYYY-MM/<file>.json
+    const archiveRoot = join(inbox.root, "archive");
+    expect(existsSync(archiveRoot)).toBe(true);
+  });
+
+  test("checkMessages opportunistically archives old cur entries", async () => {
+    const { getInbox } = await import("../src/utils/mail.js");
+    const inbox = getInbox("kern");
+    const { writeFileSync, mkdirSync, utimesSync, readdirSync } = await import("node:fs");
+    mkdirSync(inbox.cur, { recursive: true });
+
+    // Plant a 60-day-old entry in cur/
+    const oldFile = join(inbox.cur, "ancient.json");
+    writeFileSync(oldFile, JSON.stringify({ id: "ancient", from: "anvil", to: "kern", body: "x", timestamp: new Date().toISOString() }));
+    const sixtyDaysAgo = new Date(Date.now() - 60 * 86_400_000);
+    utimesSync(oldFile, sixtyDaysAgo, sixtyDaysAgo);
+
+    // Send a new msg + check — should trigger auto-archive
+    sendMessage("kern", "fresh", "anvil");
+    checkMessages("kern");
+
+    // Ancient should be archived, fresh should be in cur/
+    const curContents = readdirSync(inbox.cur).filter((f) => f.endsWith(".json"));
+    expect(curContents).not.toContain("ancient.json");
+    expect(curContents.length).toBe(1); // just the freshly-checked one
   });
 });
 


### PR DESCRIPTION
## Summary

Two compounding bugs from yesterday's S5 dispatch stall. The honest-NACK fix (cli#294) made the failure mode loud but didn't address the trigger.

### Bug 1: cap counted new + cur (semantic)

`countInboxMessages` counted both unprocessed (`new/`) and processed-not-archived (`cur/`) entries against the 100-msg cap. A busy agent that acked its mail kept processed messages in cur/ indefinitely; once cur/ filled to 100, ALL fresh dispatches NACK'd with "Inbox full" silently — the agent was working, but the queue was wedged.

Anvil hit this 2026-05-19 with 100 cur/ entries dating back to May 4. The S5 dispatch I sent him stranded for 8h before diagnosis.

**Fix:** `countInboxMessages` now counts `new/` only. Cap remains back-pressure for "agent isn't processing," not "agent ran for too long."

### Bug 2: cur/ grew unbounded (operational)

Even with the new semantic, cur/ would still grow forever (disk pressure, operator confusion).

**Fix:** New `archiveOldCur(agent, maxAgeDays=30)` moves cur entries older than the cutoff to `archive/YYYY-MM/`. `checkMessages` calls it opportunistically each time, so cur/ self-cleans as the agent works.

The 30d default is conservative: ack'd mail is essentially done; audit log + git history are the durable record.

## Test plan

- [x] `countInboxMessages counts new/ only — drops after check` — verifies new semantic
- [x] `100 messages in cur does NOT block new sends` — Anvil-regression test, the exact scenario we lived through
- [x] `archiveOldCur moves only entries older than maxAgeDays` — 60d archives, 10d stays, fresh stays
- [x] `checkMessages opportunistically archives old cur entries` — auto-archive on next check
- [x] Updated existing `countInboxMessages drops after ack` test to reflect new semantic
- [x] **21/21 mail tests pass.**

Also fixed a pre-existing test-isolation bug: `getInbox()` prefers `~/.tps/branch-office/<agent>/mail` over `TPS_MAIL_DIR`, so the test setup needed to override `HOME` alongside `TPS_MAIL_DIR`. Surfaced when today's K&S cycles filled kern's real on-host inbox past the cap and the tests started leaking into it.

## Closes

- P1 bead "Agent inbox auto-drain" (paired with cli#294's honest-NACK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)