### PR TITLE
fix(deps): pin ws to ^8.20.1 (clear GHSA-58qx-3vcg-4xpx) — ops-i4ai

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@tpsdev-ai/cli",
       "dependencies": {
         "handlebars": "^4.7.9",
+        "ws": "^8.20.1",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
@@ -131,6 +132,9 @@
         "typescript": "^5.7.0",
       },
     },
+  },
+  "overrides": {
+    "ws": "^8.20.1",
   },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.1.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw=="],
@@ -385,7 +389,7 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
@@ -398,8 +402,6 @@
     "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   "author": "tpsdev-ai",
   "license": "Apache-2.0",
   "dependencies": {
-    "handlebars": "^4.7.9"
+    "handlebars": "^4.7.9",
+    "ws": "^8.20.1"
+  },
+  "overrides": {
+    "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
## Summary

Pin `ws` to `^8.20.1` via root `overrides` field to clear `GHSA-58qx-3vcg-4xpx` (moderate: uninitialized memory disclosure). The vulnerability has been blocking the CI `Dependency Audit` check on main since #291 merged.

## Why

`bun audit` flagged `ws <8.20.1` reaching us three ways:
- `workspace:@tpsdev-ai/cli` direct dependency
- `ink › ws` (was 8.19.0)
- `react-devtools-core › ws` (was 7.5.10)

Direct dep bump alone wasn't enough — transitive consumers still pinned the vulnerable version. The `overrides` field forces a single resolution across all dependents.

## Verification

- `bun audit` — **no vulnerabilities found** (previously: 1 moderate).
- `bun pm ls` confirms `ws@8.20.1` at workspace root.
- `bun.lock` diff drops the nested `react-devtools-core/ws@7.5.10` entry — now resolves to the top-level 8.20.1.
- 21/21 mail tests still pass (no runtime behavior change).

## Test plan

- [x] `bun audit` clean locally
- [x] `bun test packages/cli/test/mail.test.ts` passes
- [ ] CI `Dependency Audit` turns green (currently failing on main)
- [ ] Full CI green on this PR

ops-i4ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)