### PR TITLE
test(mail): raise quota-100 timeout to 15s (ops-l5tl)

### DIFF
--- a/packages/cli/test/mail.test.ts
+++ b/packages/cli/test/mail.test.ts
@@ -54,7 +54,7 @@ describe("mail utils", () => {
     expect(readdirSync(inbox.cur).length).toBe(1);
   });
 
-  test("quota enforces max 100 messages", () => {
+  test("quota enforces max 100 messages", { timeout: 15000 }, () => {
     for (let i = 0; i < 100; i++) {
       sendMessage("kern", `msg-${i}`, "anvil");
     }


### PR DESCRIPTION
## Summary

The mail quota test exercises 100 sendMessage calls (atomicWrite + rename per call), which is borderline against bun's 5s default timeout on slower CI runners. Observed flaking on cli#296 run 26132092302 — empty-commit re-trigger passed but the close call cost a merge cycle.

Raises the per-test timeout to 15s — 3x safety margin against typical p99 fs latency on CI.

## Diff

One line — adds `{ timeout: 15000 }` as second arg to `test(...)`.

## Verification

- `bun test packages/cli/test/mail.test.ts` — 21/21 pass locally
- No behavior change; test still asserts the same invariants

ops-l5tl