### PR TITLE
feat(secrets): S2 credential substrate - verify, list, show, scan, adopt-single commands

### DIFF
--- a/packages/cli/bin/tps.ts
+++ b/packages/cli/bin/tps.ts
@@ -134,7 +134,7 @@ const cli = meow(
       noFlair: { type: "boolean", default: false },
       forceReinstallFlair: { type: "boolean", default: false },
       purgeFlair: { type: "boolean", default: false },
-      // ops-568p: Cred substrate S1 (credentials manifest)
+      // ops-568p: Cred substrate S1+S2 (credentials manifest)
       apply: { type: "boolean", default: false },
       expires: { type: "string" },
       expiresWithin: { type: "string" },
@@ -151,6 +151,8 @@ const cli = meow(
       credType: { type: "string" },
       check: { type: "boolean", default: false },
       noGuard: { type: "boolean", default: false },
+      staleOnly: { type: "boolean", default: false },
+      root: { type: "string" },
       // Facts substrate flags
       failOnDrift: { type: "boolean", default: false },
       noVerify: { type: "boolean", default: false },
@@ -790,21 +792,23 @@ async function main() {
       const action = rest[0];
       const allowedActions = [
         "set", "list", "remove",
-        "show", "emit", "register", "unregister", "adopt", "verify",
+        "show", "emit", "register", "unregister", "adopt", "verify", "scan",
         "rotate-github-pat", "list-github-pats",
       ];
       if (!action || !allowedActions.includes(action)) {
         console.error([
           "Usage:",
           "  tps secrets set <KEY>=<VALUE>",
-          "  tps secrets list [--owner <id>] [--expires-within <d>] [--json]",
+          "  tps secrets list [--owner <id>] [--scope <s>] [--type <t>] [--stale-only] [--expires-within <d>] [--json]",
           "  tps secrets remove <KEY>",
           "  tps secrets show <name> [--json]",
           "  tps secrets emit <name>",
           "  tps secrets register <name> --path <p> --type <t> --owner <o> [--scope <s>] [--expires <iso>] [--sensitivity <level>]",
           "  tps secrets unregister <name>",
           "  tps secrets adopt [--dry-run] [--apply] [--non-interactive] [--secrets-dir <dir>] [--keys-dir <dir>]",
-          "  tps secrets verify [--fix] [--json]",
+          "  tps secrets adopt <path-or-name>  (single candidate)",
+          "  tps secrets verify [--scope <s>] [--type <t>] [--fix] [--fail-on-drift] [--json]",
+          "  tps secrets scan [--root <path>] [--json]",
           "  tps secrets rotate-github-pat <agent>     (reads token from stdin/pipe; never on argv)",
           "  tps secrets list-github-pats              (probes all PATs + keyring entries)",
         ].join("\n"));
@@ -830,13 +834,23 @@ async function main() {
       if (
         action === "show" || action === "emit" ||
         action === "register" || action === "unregister" ||
-        action === "adopt" || action === "verify"
+        action === "adopt" || action === "verify" ||
+        action === "scan"
       ) {
         const { runSecrets } = await import("../src/commands/secrets.js");
+
+        // Detect adopt-single: `tps secrets adopt <path-or-name>` with a positional arg
+        const effectiveAction = (action === "adopt" && rest[1])
+          ? "adopt-single"
+          : action;
+
         await runSecrets({
-          action: action as any,
+          action: effectiveAction as any,
           key: rest[1],
           owner: cli.flags.owner as string | undefined,
+          scope: cli.flags.scope as string | undefined,
+          type: cli.flags.credType as string | undefined,
+          staleOnly: (cli.flags as any).staleOnly as boolean | undefined,
           expiresWithin: cli.flags.expiresWithin as string | undefined,
           registerPath: cli.flags.path as string | undefined,
           registerType: cli.flags.credType as string | undefined,
@@ -850,6 +864,8 @@ async function main() {
           adoptIdentityDir: (cli.flags as any).identityDir as string | undefined,
           adoptFlairKeysDir: (cli.flags as any).flairKeysDir as string | undefined,
           verifyFix: cli.flags.fix as boolean,
+          failOnDrift: (cli.flags as any).failOnDrift as boolean | undefined,
+          scanRoot: (cli.flags as any).root as string | undefined,
           json: cli.flags.json as boolean,
         });
         break;

--- a/packages/cli/src/commands/secrets.ts
+++ b/packages/cli/src/commands/secrets.ts
@@ -1,8 +1,8 @@
 /**
- * secrets.ts — Cred Substrate S1 secrets command
+ * secrets.ts — Cred Substrate S1+S2 secrets command
  *
  * Extends the vault-based secrets commands with credential manifest operations:
- *   list (manifest-aware), show, emit, register, unregister, adopt, verify
+ *   list (manifest-aware), show, emit, register, unregister, adopt, verify, scan
  */
 
 import { loadFromVault, TpsVault } from "../utils/identity.js";
@@ -10,22 +10,36 @@ import {
   readManifest,
   writeManifest,
   expandPath,
+  manifestPath,
   CredentialsManifest,
   CredentialEntry,
   CredentialType,
   RESERVED_TYPES,
   sensitivityForType,
   VerifyResult,
+  VerifyIssue,
   verifyAll,
   verifyFixAll,
+  verifyEntry,
+  verifySummary,
   filterExpiresWithin,
+  filterByScope,
+  filterByType,
+  filterStaleOnly,
+  isEntryStale,
+  entryAge,
   walkAdoptCandidates,
+  scanOrphans,
+  adoptSingle,
   AdoptResult,
   AdoptCandidate,
+  inferTypeFromPath,
+  inferOwnerFromName,
 } from "../utils/credentials-manifest.js";
-import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync, renameSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, dirname } from "node:path";
+import { join, dirname, basename } from "node:path";
+import { tmpdir } from "node:os";
 
 // ---------------------------------------------------------------------------
 // CLI entry point types
@@ -35,8 +49,10 @@ export type SecretsAction =
   | "set" | "list" | "remove"       // vault (legacy)
   | "show" | "emit"                 // manifest read
   | "register" | "unregister"       // manifest write
-  | "adopt"                         // scan + propose
-  | "verify";                       // check manifest integrity
+  | "adopt"                         // bulk scan + propose
+  | "adopt-single"                  // adopt a single candidate
+  | "verify"                        // check manifest integrity
+  | "scan";                          // detect orphans
 
 export interface SecretsArgs {
   action: SecretsAction;
@@ -46,6 +62,9 @@ export interface SecretsArgs {
   // list filtering
   owner?: string;
   expiresWithin?: string;
+  scope?: string;
+  type?: string;
+  staleOnly?: boolean;
   // register
   registerPath?: string;
   registerType?: string;
@@ -61,6 +80,9 @@ export interface SecretsArgs {
   adoptFlairKeysDir?: string;
   // verify
   verifyFix?: boolean;
+  failOnDrift?: boolean;
+  // scan
+  scanRoot?: string;
   // common
   json?: boolean;
 }
@@ -95,8 +117,14 @@ export async function runSecrets(args: SecretsArgs): Promise<void> {
     case "adopt":
       handleAdopt(args);
       break;
+    case "adopt-single":
+      handleAdoptSingle(args);
+      break;
     case "verify":
       handleVerify(args);
+      break;
+    case "scan":
+      handleScan(args);
       break;
   }
 }
@@ -185,9 +213,24 @@ async function handleList(args: SecretsArgs): Promise<void> {
     entries = filtered;
   }
 
+  // Filter by scope (S2)
+  if (args.scope) {
+    entries = filterByScope(entries, args.scope);
+  }
+
+  // Filter by type (S2)
+  if (args.type) {
+    entries = filterByType(entries, args.type);
+  }
+
   // Filter by expiry
   if (args.expiresWithin) {
     entries = filterExpiresWithin(manifest, args.expiresWithin);
+  }
+
+  // Filter stale-only (S2)
+  if (args.staleOnly) {
+    entries = filterStaleOnly(entries);
   }
 
   if (args.json) {
@@ -200,13 +243,28 @@ async function handleList(args: SecretsArgs): Promise<void> {
     return;
   }
 
+  // S2: Render as table with: name, type, scope, status, age
+  const rows: string[][] = [];
   for (const [name, entry] of Object.entries(entries)) {
-    const owners = entry.owners.length > 0 ? `[${entry.owners.join(", ")}]` : "[none]";
-    const expires = entry.expires ? ` expires: ${entry.expires}` : "";
-    console.log(`  ${name}`);
-    console.log(`    path: ${entry.path}  type: ${entry.type}  sensitivity: ${entry.sensitivity}${expires}`);
-    console.log(`    owners: ${owners}`);
-    console.log("");
+    const status = isEntryStale(entry) ? "⚠ STALE" : "✓";
+    const age = entryAge(entry) ?? "—";
+    rows.push([name, entry.type, entry.scope ?? "—", status, age]);
+  }
+
+  // Table header
+  const cols = ["Name", "Type", "Scope", "Status", "Age"];
+  const widths = cols.map((_, i) =>
+    Math.max(cols[i].length, ...rows.map(r => (r[i] ?? "").length))
+  );
+
+  const pad = (s: string, w: number) => s + " ".repeat(Math.max(0, w - s.length));
+  const header = cols.map((c, i) => pad(c, widths[i])).join("  ");
+  const sep = widths.map(w => "─".repeat(w)).join("  ");
+
+  console.log(header);
+  console.log(sep);
+  for (const row of rows) {
+    console.log(row.map((c, i) => pad(c, widths[i])).join("  "));
   }
 }
 
@@ -233,21 +291,36 @@ function handleShow(args: SecretsArgs): void {
   }
 
   if (args.json) {
-    console.log(JSON.stringify(entry, null, 2));
+    console.log(JSON.stringify({ entry, verify: verifyEntry(entry) }, null, 2));
     return;
   }
 
-  console.log(`Name:        ${args.key}`);
-  console.log(`Path:        ${entry.path}`);
-  console.log(`Type:        ${entry.type}`);
-  console.log(`Owners:      ${entry.owners.join(", ") || "(none)"}`);
-  console.log(`Sensitivity: ${entry.sensitivity}`);
-  if (entry.scope) console.log(`Scope:       ${entry.scope}`);
-  if (entry.issued) console.log(`Issued:      ${entry.issued}`);
-  if (entry.expires) console.log(`Expires:     ${entry.expires}`);
-  if (entry.lastRotated) console.log(`LastRotated: ${entry.lastRotated}`);
-  if (entry.lastUsed) console.log(`LastUsed:    ${entry.lastUsed}`);
-  if (entry.notes) console.log(`Notes:       ${entry.notes}`);
+  // S2: Bold name + kv lines + verify status indicator
+  console.log(`\x1b[1m${args.key}\x1b[0m`);
+  console.log(`  Path:        ${entry.path}`);
+  console.log(`  Type:        ${entry.type}`);
+  console.log(`  Owners:      ${entry.owners.join(", ") || "(none)"}`);
+  console.log(`  Sensitivity: ${entry.sensitivity}`);
+  if (entry.scope) console.log(`  Scope:       ${entry.scope}`);
+  if (entry.issued) console.log(`  Issued:      ${entry.issued}`);
+  if (entry.expires) console.log(`  Expires:     ${entry.expires}`);
+  if (entry.lastRotated) console.log(`  LastRotated: ${entry.lastRotated}`);
+  if (entry.lastUsed) console.log(`  LastUsed:    ${entry.lastUsed}`);
+  if (entry.notes) console.log(`  Notes:       ${entry.notes}`);
+
+  // Verify status
+  const vResult = verifyEntry(entry);
+  const stale = isEntryStale(entry);
+  if (vResult.ok && !stale) {
+    console.log(`  Status:      \x1b[32m✓ OK\x1b[0m`);
+  } else if (stale && vResult.ok) {
+    console.log(`  Status:      \x1b[33m⚠ STALE\x1b[0m (expired)`);
+  } else {
+    console.log(`  Status:      \x1b[31m✗ FAIL\x1b[0m`);
+    for (const issue of vResult.issues) {
+      console.log(`    ${issue.kind}: ${issue.detail}`);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -465,9 +538,24 @@ function handleVerify(args: SecretsArgs): void {
     process.exit(1);
   }
 
-  const entries = Object.entries(manifest.credentials);
-  if (entries.length === 0) {
-    console.log("Manifest is empty.");
+  // Start with all entries
+  let filteredManifest: CredentialsManifest = {
+    version: 1,
+    credentials: { ...manifest.credentials },
+  };
+
+  // Apply scope filter
+  if (args.scope) {
+    filteredManifest.credentials = filterByScope(filteredManifest.credentials, args.scope);
+  }
+
+  // Apply type filter
+  if (args.type) {
+    filteredManifest.credentials = filterByType(filteredManifest.credentials, args.type);
+  }
+
+  if (Object.keys(filteredManifest.credentials).length === 0) {
+    console.log("No entries to verify (check filters).");
     process.exit(0);
   }
 
@@ -483,26 +571,198 @@ function handleVerify(args: SecretsArgs): void {
     return;
   }
 
-  const results = verifyAll(manifest);
-  let allOk = true;
-
-  for (const [name, result] of Object.entries(results)) {
-    if (result.ok) {
-      console.log(`✓ ${name}`);
-    } else {
-      allOk = false;
-      console.log(`✗ ${name}`);
-      for (const issue of result.issues) {
-        console.log(`    ${issue.kind}: ${issue.detail}`);
-      }
-    }
-  }
-
-  console.log(`\n${allOk ? "All checks passed." : "Some checks failed."}`);
+  // S2: Use verifySummary for categorized reporting
+  const summary = verifySummary(filteredManifest);
+  let hasDrift = false;
 
   if (args.json) {
-    console.log(JSON.stringify(results, null, 2));
+    const output: Record<string, any> = {
+      ok: summary.ok,
+      stale: summary.stale,
+      missing: summary.missing,
+      drift: summary.drift,
+      entries: summary.entries.map(e => ({
+        name: e.name,
+        category: e.category,
+        issues: e.issues,
+        path: e.entry.path,
+        type: e.entry.type,
+      })),
+    };
+    console.log(JSON.stringify(output, null, 2));
+    if (args.failOnDrift && summary.drift > 0) process.exit(1);
+    return;
   }
 
-  if (!allOk) process.exit(1);
+  // Render table
+  const rows: string[][] = [];
+  const statusIcons: Record<string, string> = {
+    ok: "✓",
+    stale: "⚠",
+    missing: "✗",
+    drift: "✗",
+  };
+
+  for (const e of summary.entries) {
+    if (e.category === "drift") hasDrift = true;
+    rows.push([
+      e.name,
+      e.category.toUpperCase(),
+      statusIcons[e.category] ?? "?",
+      e.issues.length > 0 ? e.issues.map(i => `${i.kind}: ${i.detail}`).join("; ") : "—",
+    ]);
+  }
+
+  const cols = ["Name", "Category", "Status", "Details"];
+  const widths = cols.map((_, i) =>
+    Math.max(cols[i].length, ...rows.map(r => (r[i] ?? "").length))
+  );
+
+  const pad = (s: string, w: number) => s + " ".repeat(Math.max(0, w - s.length));
+  const header = cols.map((c, i) => pad(c, widths[i])).join("  ");
+  const sep = widths.map(w => "─".repeat(w)).join("  ");
+
+  console.log(header);
+  console.log(sep);
+  for (const row of rows) {
+    console.log(row.map((c, i) => pad(c, widths[i])).join("  "));
+  }
+
+  // Summary line
+  console.log(`\nOK: ${summary.ok}  STALE: ${summary.stale}  MISSING: ${summary.missing}  DRIFT: ${summary.drift}`);
+
+  if (args.failOnDrift && hasDrift) {
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// S2: Scan (find orphaned credential candidates not in manifest)
+// ---------------------------------------------------------------------------
+
+function handleScan(args: SecretsArgs): void {
+  const manifest = readManifest();
+  if (!manifest) {
+    console.error("No manifest found. Run `tps secrets adopt` to scan existing secrets.");
+    process.exit(1);
+  }
+
+  const root = args.scanRoot ?? join(homedir(), ".tps");
+  const dirs = {
+    secretsDir: join(root, "secrets"),
+    identityDir: join(root, "identity"),
+    flairKeysDir: join(homedir(), ".flair", "keys"),
+    openclawConfigPath: join(homedir(), ".openclaw", "openclaw.json"),
+  };
+
+  const orphans = scanOrphans(dirs, manifest);
+
+  if (args.json) {
+    const output = {
+      candidates: orphans.map(c => ({
+        name: c.name,
+        path: c.entry.path,
+        type: c.entry.type,
+        sensitivity: c.entry.sensitivity,
+        owners: c.entry.owners,
+      })),
+    };
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  if (orphans.length === 0) {
+    console.log("No orphaned credential candidates found.");
+    return;
+  }
+
+  console.log(`Found ${orphans.length} candidate(s) not in manifest:\n`);
+  for (const candidate of orphans) {
+    const e = candidate.entry;
+    const owners = e.owners.length > 0 ? e.owners.join(", ") : "(none)";
+    console.log(`  ${candidate.name}`);
+    console.log(`    path: ${e.path}`);
+    console.log(`    type: ${e.type}  sensitivity: ${e.sensitivity}`);
+    console.log(`    owners: ${owners}`);
+    console.log(`    → tps secrets adopt ${candidate.name}`);
+    console.log("");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// S2: Adopt a single candidate by path or name
+// ---------------------------------------------------------------------------
+
+function handleAdoptSingle(args: SecretsArgs): void {
+  const candidatePath = args.key;
+  if (!candidatePath) {
+    console.error("Usage: tps secrets adopt <path-or-name>");
+    process.exit(1);
+  }
+
+  // Resolve relative paths to the ~/.tps/secrets/ directory
+  let resolvedPath = expandPath(candidatePath);
+  if (!resolvedPath.startsWith("/") && !resolvedPath.startsWith(homedir())) {
+    // Treat as name; look in ~/.tps/secrets/<name>
+    resolvedPath = join(homedir(), ".tps", "secrets", candidatePath);
+  }
+
+  // Validate path exists
+  if (!existsSync(resolvedPath)) {
+    console.error(`Error: path does not exist: ${resolvedPath}`);
+    process.exit(1);
+  }
+
+  // Validate it's a regular file and readable
+  let content: string;
+  try {
+    const st = statSync(resolvedPath);
+    if (!st.isFile()) {
+      console.error(`Error: not a regular file: ${resolvedPath}`);
+      process.exit(1);
+    }
+    content = readFileSync(resolvedPath, "utf-8");
+  } catch {
+    console.error(`Error: cannot read file: ${resolvedPath}`);
+    process.exit(1);
+  }
+
+  // Infer metadata
+  const type = inferTypeFromPath(resolvedPath, content);
+  const credType: CredentialType = type === "unknown" ? "api-key" : type as CredentialType;
+  const name = basename(resolvedPath);
+  const owner = inferOwnerFromName(name);
+  const sensitivity = sensitivityForType(credType);
+
+  // Load manifest
+  const manifest = readManifest() ?? { version: 1, credentials: {} };
+
+  // Check for duplicate
+  const existingPaths = new Set(
+    Object.values(manifest.credentials).map(e => expandPath(e.path))
+  );
+  if (existingPaths.has(resolvedPath)) {
+    console.error(`Error: path is already registered in manifest: ${resolvedPath}`);
+    process.exit(1);
+  }
+
+  // Build entry
+  const entry: CredentialEntry = {
+    path: resolvedPath,
+    type: credType,
+    owners: owner ? [owner] : [],
+    sensitivity,
+  };
+
+  manifest.credentials[name] = entry;
+
+  // Ensure dir mode 0700 before writing
+  mkdirSync(dirname(manifestPath()), { recursive: true, mode: 0o700 });
+  writeManifest(manifest);
+
+  if (args.json) {
+    console.log(JSON.stringify(entry, null, 2));
+  } else {
+    console.log(`Adopted '${name}' (${credType}, ${sensitivity}).`);
+  }
 }

--- a/packages/cli/src/utils/credentials-manifest.ts
+++ b/packages/cli/src/utils/credentials-manifest.ts
@@ -628,3 +628,205 @@ export function filterExpiresWithin(
   }
   return filtered;
 }
+
+// ---------------------------------------------------------------------------
+// S2: Scope & type filtering
+// ---------------------------------------------------------------------------
+
+/** Filter manifest entries by scope substring match. */
+export function filterByScope(
+  entries: Record<string, CredentialEntry>,
+  scope: string
+): Record<string, CredentialEntry> {
+  const filtered: Record<string, CredentialEntry> = {};
+  for (const [name, entry] of Object.entries(entries)) {
+    if (entry.scope && entry.scope.includes(scope)) {
+      filtered[name] = entry;
+    }
+  }
+  return filtered;
+}
+
+/** Filter manifest entries by exact type match. */
+export function filterByType(
+  entries: Record<string, CredentialEntry>,
+  type: string
+): Record<string, CredentialEntry> {
+  const filtered: Record<string, CredentialEntry> = {};
+  for (const [name, entry] of Object.entries(entries)) {
+    if (entry.type === type) {
+      filtered[name] = entry;
+    }
+  }
+  return filtered;
+}
+
+// ---------------------------------------------------------------------------
+// S2: Staleness detection
+// ---------------------------------------------------------------------------
+
+/** Check if a credential entry is stale (expired, past its expires date). */
+export function isEntryStale(entry: CredentialEntry, now: Date = new Date()): boolean {
+  if (!entry.expires) return false;
+  const expiresMs = new Date(entry.expires).getTime();
+  if (isNaN(expiresMs)) return false;
+  return expiresMs < now.getTime();
+}
+
+/** Filter manifest to only entries that are stale (expired). */
+export function filterStaleOnly(
+  entries: Record<string, CredentialEntry>,
+  now: Date = new Date()
+): Record<string, CredentialEntry> {
+  const filtered: Record<string, CredentialEntry> = {};
+  for (const [name, entry] of Object.entries(entries)) {
+    if (isEntryStale(entry, now)) {
+      filtered[name] = entry;
+    }
+  }
+  return filtered;
+}
+
+// ---------------------------------------------------------------------------
+// S2: Verify summary
+// ---------------------------------------------------------------------------
+
+export type VerifyCategory = "ok" | "stale" | "missing" | "drift";
+
+export interface VerifyEntrySummary {
+  name: string;
+  category: VerifyCategory;
+  issues: VerifyIssue[];
+  entry: CredentialEntry;
+}
+
+export interface VerifySummary {
+  ok: number;
+  stale: number;
+  missing: number;
+  drift: number;
+  entries: VerifyEntrySummary[];
+}
+
+/** Run verifyAll with staleness and category classification for S2 reporting. */
+export function verifySummary(
+  manifest: CredentialsManifest,
+  now: Date = new Date()
+): VerifySummary {
+  const summary: VerifySummary = { ok: 0, stale: 0, missing: 0, drift: 0, entries: [] };
+
+  for (const [name, entry] of Object.entries(manifest.credentials)) {
+    const result = verifyEntry(entry);
+    const stale = isEntryStale(entry, now);
+
+    let category: VerifyCategory;
+    if (!result.ok) {
+      // Check if it's missing vs drift
+      if (result.issues.some(i => i.kind === "missing-file")) {
+        category = "missing";
+      } else {
+        category = "drift";
+      }
+    } else if (stale) {
+      category = "stale";
+    } else {
+      category = "ok";
+    }
+
+    summary[category]++;
+    summary.entries.push({ name, category, issues: result.issues, entry });
+  }
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// S2: Orphan scan (candidates NOT in manifest)
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk candidates and return only those that are NOT already in the manifest.
+ * Compares resolved paths.
+ */
+export function scanOrphans(
+  dirs: AdoptDirs,
+  manifest: CredentialsManifest
+): AdoptCandidate[] {
+  const result = walkAdoptCandidates(dirs);
+  const registeredPaths = new Set(
+    Object.values(manifest.credentials).map(e => expandPath(e.path))
+  );
+
+  const orphans: AdoptCandidate[] = [];
+  for (const candidate of result.candidates) {
+    const candidatePath = expandPath(candidate.entry.path);
+    if (!registeredPaths.has(candidatePath)) {
+      orphans.push(candidate);
+    }
+  }
+  return orphans;
+}
+
+/**
+ * Compute a relative "age" string for display (e.g., "3h ago", "5d ago").
+ * For entries without issued/lastUsed, returns null.
+ */
+export function entryAge(entry: CredentialEntry, now: Date = new Date()): string | null {
+  const ts = entry.issued ?? entry.lastUsed ?? entry.lastRotated;
+  if (!ts) return null;
+  const ms = now.getTime() - new Date(ts).getTime();
+  if (ms < 0 || isNaN(ms)) return null;
+
+  const minutes = Math.floor(ms / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// S2: Adopt a single candidate
+// ---------------------------------------------------------------------------
+
+/**
+ * Adopt a single file path into the manifest.
+ * Infers type, owner, and sensitivity; validates the path exists.
+ * Returns the new entry, or throws on validation failure.
+ */
+export function adoptSingle(
+  candidatePath: string,
+  name?: string
+): { name: string; entry: CredentialEntry } {
+  const resolvedPath = expandPath(candidatePath);
+
+  // Validate path exists
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`path does not exist: ${resolvedPath}`);
+  }
+
+  // Read content for type inference
+  let content: string | null = null;
+  try {
+    content = readFileSync(resolvedPath, "utf-8");
+  } catch {
+    throw new Error(`cannot read file: ${resolvedPath}`);
+  }
+
+  // Infer metadata
+  const type = inferTypeFromPath(resolvedPath, content);
+  const credType: CredentialType = type === "unknown" ? "api-key" : type as CredentialType;
+  const inferredName = name ?? basename(resolvedPath);
+  const owner = inferOwnerFromName(inferredName);
+  const sensitivity = sensitivityForType(credType);
+
+  const entry: CredentialEntry = {
+    path: resolvedPath,
+    type: credType,
+    owners: owner ? [owner] : [],
+    sensitivity,
+  };
+
+  return { name: inferredName, entry };
+}

--- a/packages/cli/test/credentials-manifest-s2.test.ts
+++ b/packages/cli/test/credentials-manifest-s2.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Credentials Manifest S2 tests
+ *
+ * Covers new S2 primitives:
+ *   filterByScope, filterByType, isEntryStale, filterStaleOnly,
+ *   verifySummary, scanOrphans, entryAge, adoptSingle
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import {
+  CredentialsManifest,
+  CredentialEntry,
+  CredentialType,
+  filterByScope,
+  filterByType,
+  isEntryStale,
+  filterStaleOnly,
+  verifySummary,
+  scanOrphans,
+  entryAge,
+  adoptSingle,
+  writeManifest,
+  readManifest,
+  expandPath,
+  manifestPath,
+} from "../src/utils/credentials-manifest";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeFixtureFile(dir: string, name: string, content: string, mode = 0o600): string {
+  const p = join(dir, name);
+  writeFileSync(p, content, { mode });
+  return p;
+}
+
+function makeEntry(overrides: Partial<CredentialEntry> = {}): CredentialEntry {
+  return {
+    path: "/tmp/test-secret",
+    type: "api-key" as CredentialType,
+    owners: ["test"],
+    sensitivity: "medium",
+    ...overrides,
+  };
+}
+
+function makeManifest(entries: Record<string, CredentialEntry>): CredentialsManifest {
+  return { version: 1, credentials: entries };
+}
+
+// ---------------------------------------------------------------------------
+// filterByScope
+// ---------------------------------------------------------------------------
+
+describe("filterByScope", () => {
+  test("matches scope substring", () => {
+    const entries = {
+      a: makeEntry({ scope: "dtrt-dev/ops" }),
+      b: makeEntry({ scope: "newton oMLX gateway" }),
+      c: makeEntry(),
+    };
+    const result = filterByScope(entries, "ops");
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.a.scope).toBe("dtrt-dev/ops");
+  });
+
+  test("returns empty when no match", () => {
+    const entries = { a: makeEntry({ scope: "backend" }) };
+    const result = filterByScope(entries, "nonexistent");
+    expect(Object.keys(result).length).toBe(0);
+  });
+
+  test("ignores entries without scope", () => {
+    const entries = { a: makeEntry(), b: makeEntry({ scope: "ops" }) };
+    const result = filterByScope(entries, "ops");
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.b).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterByType
+// ---------------------------------------------------------------------------
+
+describe("filterByType", () => {
+  test("matches exact type", () => {
+    const entries = {
+      a: makeEntry({ type: "api-key" }),
+      b: makeEntry({ type: "github-pat-fine-grained" }),
+      c: makeEntry({ type: "api-key" }),
+    };
+    const result = filterByType(entries, "api-key");
+    expect(Object.keys(result).length).toBe(2);
+    expect(result.a).toBeDefined();
+    expect(result.c).toBeDefined();
+  });
+
+  test("returns empty when no match", () => {
+    const entries = { a: makeEntry({ type: "api-key" }) };
+    expect(Object.keys(filterByType(entries, "ssh-key")).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isEntryStale
+// ---------------------------------------------------------------------------
+
+describe("isEntryStale", () => {
+  test("returns false when no expires field", () => {
+    expect(isEntryStale(makeEntry())).toBe(false);
+  });
+
+  test("returns true when expired", () => {
+    const entry = makeEntry({ expires: "2020-01-01T00:00:00Z" });
+    expect(isEntryStale(entry)).toBe(true);
+  });
+
+  test("returns false when not yet expired", () => {
+    const future = new Date(Date.now() + 86400000 * 30).toISOString();
+    const entry = makeEntry({ expires: future });
+    expect(isEntryStale(entry)).toBe(false);
+  });
+
+  test("handles invalid date gracefully", () => {
+    expect(isEntryStale(makeEntry({ expires: "not-a-date" }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterStaleOnly
+// ---------------------------------------------------------------------------
+
+describe("filterStaleOnly", () => {
+  test("filters to only expired entries", () => {
+    const entries = {
+      fresh: makeEntry({ expires: new Date(Date.now() + 86400000 * 30).toISOString() }),
+      stale: makeEntry({ expires: "2020-01-01T00:00:00Z" }),
+      none: makeEntry(),
+    };
+    const result = filterStaleOnly(entries);
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.stale).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifySummary
+// ---------------------------------------------------------------------------
+
+describe("verifySummary", () => {
+  let tmp: string;
+
+  beforeAll(() => {
+    tmp = mkdtempSync(join(tmpdir(), "tps-s2-verify-"));
+  });
+
+  afterAll(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("categorizes OK/STALE/MISSING/DRIFT correctly", () => {
+    const okFile = writeFixtureFile(tmp, "ok-key", "test-key-12345678", 0o600);
+    // STALE: valid file but expired
+    const staleFile = writeFixtureFile(tmp, "stale-key", "abc123def456", 0o600);
+    // DRIFT: file exists but bad mode
+    const driftFile = writeFixtureFile(tmp, "drift-key", "abc123def456", 0o644);
+    // MISSING: file doesn't exist
+
+    const manifest = makeManifest({
+      "ok-cred": { path: okFile, type: "api-key", owners: ["test"], sensitivity: "medium" },
+      "stale-cred": {
+        path: staleFile,
+        type: "api-key",
+        owners: ["test"],
+        sensitivity: "medium",
+        expires: "2020-01-01T00:00:00Z",
+      },
+      "drift-cred": { path: driftFile, type: "api-key", owners: ["test"], sensitivity: "medium" },
+      "missing-cred": { path: join(tmp, "nonexistent"), type: "api-key", owners: ["test"], sensitivity: "medium" },
+    });
+
+    const summary = verifySummary(manifest);
+
+    expect(summary.ok).toBe(1);
+    expect(summary.stale).toBe(1);
+    expect(summary.drift).toBe(1);
+    expect(summary.missing).toBe(1);
+    expect(summary.entries.length).toBe(4);
+  });
+
+  test("all ok entries when everything is clean", () => {
+    const f1 = writeFixtureFile(tmp, "a-key", "my-key-data-1234", 0o600);
+    const f2 = writeFixtureFile(tmp, "b-key", "another-key-5678", 0o600);
+
+    const manifest = makeManifest({
+      a: { path: f1, type: "api-key", owners: ["test"], sensitivity: "medium" },
+      b: { path: f2, type: "api-key", owners: ["test"], sensitivity: "medium" },
+    });
+
+    const summary = verifySummary(manifest);
+    expect(summary.ok).toBe(2);
+    expect(summary.stale).toBe(0);
+    expect(summary.missing).toBe(0);
+    expect(summary.drift).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanOrphans
+// ---------------------------------------------------------------------------
+
+describe("scanOrphans", () => {
+  let tmp: string;
+
+  beforeAll(() => {
+    tmp = mkdtempSync(join(tmpdir(), "tps-s2-scan-"));
+    // Create a secrets dir with one file
+    const secretsDir = join(tmp, "secrets");
+    mkdirSync(secretsDir, { recursive: true, mode: 0o700 });
+    writeFixtureFile(secretsDir, "registered-secret", "ghp_test12345", 0o600);
+    writeFixtureFile(secretsDir, "unregistered-secret", "api-key-value-12", 0o600);
+  });
+
+  afterAll(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("returns only candidates NOT in manifest", () => {
+    const dirs = {
+      secretsDir: join(tmp, "secrets"),
+      identityDir: join(tmp, "identity"),
+      flairKeysDir: join(tmp, "flair-keys"),
+      openclawConfigPath: join(tmp, "openclaw.json"),
+    };
+
+    // Manifest registers one file
+    const manifest = makeManifest({
+      "registered-secret": {
+        path: join(tmp, "secrets", "registered-secret"),
+        type: "github-pat-classic",
+        owners: ["test"],
+        sensitivity: "medium",
+      },
+    });
+
+    const orphans = scanOrphans(dirs, manifest);
+    expect(orphans.length).toBe(1);
+    expect(orphans[0].name).toBe("unregistered-secret");
+  });
+
+  test("returns empty when all candidates are registered", () => {
+    const dirs = {
+      secretsDir: join(tmp, "secrets"),
+      identityDir: join(tmp, "identity"),
+      flairKeysDir: join(tmp, "flair-keys"),
+      openclawConfigPath: join(tmp, "openclaw.json"),
+    };
+
+    const manifest = makeManifest({
+      "registered-secret": {
+        path: join(tmp, "secrets", "registered-secret"),
+        type: "github-pat-classic",
+        owners: ["test"],
+        sensitivity: "medium",
+      },
+      "unregistered-secret": {
+        path: join(tmp, "secrets", "unregistered-secret"),
+        type: "api-key",
+        owners: ["test"],
+        sensitivity: "medium",
+      },
+    });
+
+    expect(scanOrphans(dirs, manifest).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// entryAge
+// ---------------------------------------------------------------------------
+
+describe("entryAge", () => {
+  test("returns null when no timestamp fields", () => {
+    expect(entryAge(makeEntry())).toBeNull();
+  });
+
+  test("returns 'just now' for recent timestamps", () => {
+    const now = new Date();
+    const entry = makeEntry({ issued: new Date(now.getTime() - 30000).toISOString() });
+    const age = entryAge(entry, now);
+    expect(age).toBe("just now");
+  });
+
+  test("returns minutes ago format", () => {
+    const now = new Date();
+    const entry = makeEntry({ issued: new Date(now.getTime() - 300000).toISOString() });
+    expect(entryAge(entry, now)).toBe("5m ago");
+  });
+
+  test("returns hours ago format", () => {
+    const now = new Date();
+    const entry = makeEntry({ issued: new Date(now.getTime() - 3600000 * 3).toISOString() });
+    expect(entryAge(entry, now)).toBe("3h ago");
+  });
+
+  test("returns days ago format", () => {
+    const now = new Date();
+    const entry = makeEntry({ issued: new Date(now.getTime() - 86400000 * 2).toISOString() });
+    expect(entryAge(entry, now)).toBe("2d ago");
+  });
+
+  test("uses lastUsed fallback", () => {
+    const now = new Date();
+    const entry = makeEntry({ lastUsed: new Date(now.getTime() - 3600000).toISOString() });
+    expect(entryAge(entry, now)).toBe("1h ago");
+  });
+
+  test("uses lastRotated fallback", () => {
+    const now = new Date();
+    const entry = makeEntry({ lastRotated: new Date(now.getTime() - 60000).toISOString() });
+    expect(entryAge(entry, now)).toBe("1m ago");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adoptSingle
+// ---------------------------------------------------------------------------
+
+describe("adoptSingle", () => {
+  let tmp: string;
+  let manifestFile: string;
+
+  beforeAll(() => {
+    tmp = mkdtempSync(join(tmpdir(), "tps-s2-adopt-"));
+    // Create a secrets dir and a test file
+    const secretsDir = join(tmp, "secrets");
+    mkdirSync(secretsDir, { recursive: true, mode: 0o700 });
+    writeFixtureFile(secretsDir, "github-pat-classic-token", "ghp_fresh12345678", 0o600);
+
+    // Set up a manifest in a temp location
+    manifestFile = join(tmp, "manifest", "index.json");
+    mkdirSync(dirname(manifestFile), { recursive: true, mode: 0o700 });
+    writeFileSync(manifestFile, JSON.stringify({ version: 1, credentials: {} }), { mode: 0o644 });
+  });
+
+  afterAll(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("adopts a single file successfully", () => {
+    const filePath = join(tmp, "secrets", "github-pat-classic-token");
+    const result = adoptSingle(filePath);
+    expect(result.name).toBe("github-pat-classic-token");
+    expect(result.entry.type).toBe("github-pat-classic");
+    expect(result.entry.sensitivity).toBe("medium");
+  });
+
+  test("rejects non-existent path", () => {
+    expect(() => adoptSingle(join(tmp, "nonexistent"))).toThrow(/does not exist/);
+  });
+
+  test("rejects unreadable path (directory)", () => {
+    expect(() => adoptSingle(tmp)).toThrow();
+  });
+
+  test("inferred type is api-key for unknown content", () => {
+    const unknownFile = writeFixtureFile(join(tmp, "secrets"), "unknown-file", "some random content", 0o600);
+    const result = adoptSingle(unknownFile);
+    expect(result.entry.type).toBe("api-key");
+  });
+
+  test("correctly identifies github-pat-fine-grained", () => {
+    const fgFile = writeFixtureFile(join(tmp, "secrets"), "github-pat-fine-grain-key", "github_pat_" + "x".repeat(82), 0o600);
+    const result = adoptSingle(fgFile);
+    expect(result.entry.type).toBe("github-pat-fine-grained");
+    expect(result.entry.sensitivity).toBe("medium");
+  });
+
+  test("high sensitivity for harper-admin-password", () => {
+    const pw = "my-super-secret-admin-password";
+    const pwFile = writeFixtureFile(join(tmp, "secrets"), "flair-admin-pass-rockit", pw, 0o600);
+    const result = adoptSingle(pwFile);
+    expect(result.entry.type).toBe("harper-admin-password");
+    expect(result.entry.sensitivity).toBe("high");
+  });
+
+  test("correctly infers discord-webhook type", () => {
+    const whFile = writeFixtureFile(
+      join(tmp, "secrets"),
+      "pulse-discord-webhook",
+      "https://discord.com/api/webhooks/123456789/abcdefghij",
+      0o600,
+    );
+    const result = adoptSingle(whFile);
+    expect(result.entry.type).toBe("discord-webhook");
+  });
+});


### PR DESCRIPTION
## S2 Credential Substrate

Builds on S1 (manifest + walkAdoptCandidates, #292) and S5 (leak-shape guard, #293).

### New commands

- **`tps secrets verify`** — walks manifest, reports OK/STALE/MISSING/DRIFT with categorized table + summary counts. Supports `--scope`, `--type`, `--fail-on-drift`, `--json`
- **`tps secrets show <name>`** — manifest entry with verify status indicator (✓/⚠/✗)
- **`tps secrets list`** — enhanced with `--scope`, `--type`, `--stale-only` filtering + table output
- **`tps secrets scan`** — finds orphaned credential candidates (not in manifest) using walkAdoptCandidates
- **`tps secrets adopt <path-or-name>`** — single candidate adoption via inferTypeFromPath/sensitivityForType

### Changes

| File | What |
|------|------|
| `credentials-manifest.ts` | filterByScope, filterByType, isEntryStale, filterStaleOnly, verifySummary, scanOrphans, entryAge, adoptSingle |
| `secrets.ts` | Enhanced list/show/verify handlers + new scan/adoptSingle handlers |
| `bin/tps.ts` | New flags (--stale-only, --fail-on-drift, --root), scan/adopt-single dispatch |

### Tests
28 new Bun tests covering filtering, staleness, verify categorization, orphan scanning, adoptSingle (happy + error paths). All 96 credentials tests pass (68 S1 + 28 S2).