### PR TITLE
ci: wrap bun install with Socket Firewall (sfw)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,10 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - name: Build workspace packages
         run: bun run build
       - name: Build ${TARGET}
@@ -106,7 +109,10 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - name: Build linux-x64 release binary
         run: |
           PKG_VERSION=$(node -p "require('./packages/cli/package.json').version")
@@ -152,7 +158,10 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - name: Build agent package
         run: bun run --filter @tpsdev-ai/agent build
       - name: Publish agent package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
       - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bun run build
 
   lint:
@@ -29,10 +29,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
       - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bun run lint:ci
 
   test:
@@ -44,10 +44,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
       - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bun run build
       - run: |
           chmod +x packages/cli/test/fakes/nono/bin/nono 2>/dev/null || true
@@ -61,10 +61,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
       - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - name: Check for known vulnerabilities
         run: bun audit
 
@@ -85,10 +85,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: 1.3.10
-      - run: bun install --frozen-lockfile
       - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - name: Build agent package (required by CLI compile)
         run: cd packages/agent && bun run build
       - name: Build compiled binary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           bun-version: "1.3.10"
       - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
       - run: bun run build
 
   lint:
@@ -27,6 +30,9 @@ jobs:
         with:
           bun-version: "1.3.10"
       - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
       - run: bun run lint:ci
 
   test:
@@ -39,6 +45,9 @@ jobs:
         with:
           bun-version: "1.3.10"
       - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
       - run: bun run build
       - run: |
           chmod +x packages/cli/test/fakes/nono/bin/nono 2>/dev/null || true
@@ -53,6 +62,9 @@ jobs:
         with:
           bun-version: "1.3.10"
       - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
       - name: Check for known vulnerabilities
         run: bun audit
 
@@ -74,6 +86,9 @@ jobs:
         with:
           bun-version: 1.3.10
       - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
       - name: Build agent package (required by CLI compile)
         run: cd packages/agent && bun run build
       - name: Build compiled binary


### PR DESCRIPTION
## Summary

Adds [Socket Firewall (sfw)](https://socket.dev/firewall) to wrap every \`bun install --frozen-lockfile\` step in CI. Blocks known-malicious packages at install time via an ephemeral HTTP proxy. Complements \`bun audit\` (which only catches known vulns in already-locked deps).

### What changes

- \`test.yml\` — 5 install sites (build, lint, test, audit, binary-smoke) now run \`sfw bun install\`
- \`release.yml\` — 3 install sites wrapped
- All \`socketdev/action\` uses pinned to \`ba6de6cc05 # v1.3.2\`

### Mechanism

\`socketdev/action\` sets up an ephemeral HTTP proxy + installs the sfw binary. \`sfw bun install\` routes npm-registry traffic through the proxy, which checks each fetch against Socket's safety API before allowing it.

Verified locally: sfw wraps bun cleanly despite docs only listing npm/yarn/pnpm/pip/uv/cargo. Output: "Protected by Socket Firewall" + per-package "fetched successfully" tally.

### Part of an org-wide rollout

Same change shipping in parallel for:
- tpsdev-ai/bob — PR https://github.com/tpsdev-ai/bob/pull/14
- tpsdev-ai/flair — PR forthcoming

### Test plan

- [ ] CI green with sfw wrapping each install
- [ ] K&S ensemble (post via gh-as <agent> pr review — GH review is the reply, no TPS mail):
  - Sherlock: pinned SHA correctness; mode=firewall-free safe in public-repo CI context?
  - Kern: any perf regression from the proxy across the 8 install sites? (Expect <2s overhead per site.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)