### PR TITLE
feat(lib): signEnvelope() — Ed25519 sig over TPS envelope + delegation chain

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@tpsdev-ai/cli",
       "dependencies": {
+        "canonicalize": "^3.0.0",
         "handlebars": "^4.7.9",
         "ws": "^8.20.1",
       },
@@ -228,6 +229,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "canonicalize": ["canonicalize@3.0.0", "", { "bin": { "canonicalize": "bin/canonicalize.js" } }, "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "tpsdev-ai",
   "license": "Apache-2.0",
   "dependencies": {
+    "canonicalize": "^3.0.0",
     "handlebars": "^4.7.9",
     "ws": "^8.20.1"
   },

--- a/packages/cli/src/lib/signEnvelope.ts
+++ b/packages/cli/src/lib/signEnvelope.ts
@@ -1,0 +1,167 @@
+/**
+ * signEnvelope — Ed25519 signature over TPS mail envelope + delegation chain.
+ *
+ * Signs every agent-kind entry in the delegation chain whose signature is
+ * null/missing, then signs the outer envelope. Uses JCS (RFC 8785)
+ * canonicalization for deterministic byte-level signing input.
+ */
+
+import * as ed from "@noble/ed25519";
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+
+// Ensure sync sha512 is wired (same pattern as identity.ts).
+import { hashes } from "@noble/ed25519";
+hashes.sha512 = (message: Uint8Array) => {
+  return new Uint8Array(createHash("sha512").update(message).digest());
+};
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface ChainEntry {
+  agent: string;
+  kind: "human" | "agent";
+  timestamp: string; // ISO-8601 UTC
+  rationale: string;
+  signature: string | null; // "ed25519:<base64>" or null for human
+}
+
+export interface Envelope {
+  v: number;
+  from: string;
+  to: string;
+  subject?: string;
+  body: string;
+  messageId: string;
+  timestamp: string;
+  delegationChain: ChainEntry[];
+  signature?: string; // populated by signEnvelope
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function base64Encode(buf: Uint8Array): string {
+  return Buffer.from(buf).toString("base64");
+}
+
+/**
+ * Sign payload bytes with an Ed25519 seed (32 bytes).
+ * Returns a 64-byte signature.
+ */
+function signPayload(payload: Uint8Array, seed: Uint8Array): Uint8Array {
+  return ed.sign(payload, seed);
+}
+
+/**
+ * Deep-clone an envelope so we never mutate the input.
+ */
+function cloneEnvelope(e: Envelope): Envelope {
+  return JSON.parse(JSON.stringify(e)) as Envelope;
+}
+
+// ─── Core ───────────────────────────────────────────────────────────────────
+
+/**
+ * Sign an envelope:
+ * - For each agent-kind chain entry whose signature is null/missing, generate
+ *   sig over jcs({ prior: chain[0..i], entry: { ...entry, signature: undefined } })
+ *   using the agent's privkey.
+ * - Then compute outer sig over jcs({ ...envelope, signature: undefined })
+ *   using the LAST chain entry's privkey (which must equal envelope.from).
+ *
+ * Caller passes privkeys by agent name. For PR-1 simplicity, accept a map:
+ *   keysByAgent: { [agentName: string]: Buffer (32-byte Ed25519 seed) }
+ *
+ * Returns envelope with chain entry sigs and outer sig populated.
+ * Mutates a copy, does not mutate input.
+ */
+export function signEnvelope(
+  envelope: Envelope,
+  keysByAgent: Record<string, Buffer>,
+): Envelope {
+  const chain = envelope.delegationChain;
+
+  // ── Validation ────────────────────────────────────────────────────────
+
+  // 1. Chain tip must match envelope.from
+  const chainTip = chain[chain.length - 1];
+  if (!chainTip || chainTip.agent !== envelope.from) {
+    throw new Error(
+      `Envelope from "${envelope.from}" must equal delegation chain tip agent "${chainTip?.agent ?? "(empty chain)"}"`,
+    );
+  }
+
+  // 2. Check human entries don't have signatures
+  for (const entry of chain) {
+    if (entry.kind === "human" && entry.signature !== null) {
+      throw new Error(
+        `Human-kind chain entry for "${entry.agent}" must have null signature`,
+      );
+    }
+  }
+
+  // 3. Collect all agents that need a private key
+  const agentsNeedingKey = new Set<string>();
+  for (const entry of chain) {
+    if (entry.kind === "agent" && entry.signature === null) {
+      agentsNeedingKey.add(entry.agent);
+    }
+  }
+  // Outer sig always needs envelope.from's key
+  agentsNeedingKey.add(envelope.from);
+
+  for (const agent of agentsNeedingKey) {
+    if (!keysByAgent[agent]) {
+      throw new Error(
+        `Missing private key for agent "${agent}"`,
+      );
+    }
+  }
+
+  // ── Sign chain entries ────────────────────────────────────────────────
+
+  const result = cloneEnvelope(envelope);
+  const resultChain = result.delegationChain;
+
+  for (let i = 0; i < resultChain.length; i++) {
+    const entry = resultChain[i];
+    if (entry.kind !== "agent") continue;
+    if (entry.signature !== null) continue; // idempotent: skip already-signed
+
+    // Build signing payload: { prior: chain[0..i], entry: { ...entry, signature: undefined } }
+    const prior = resultChain.slice(0, i);
+    const entryForSig: ChainEntry & { signature: undefined } = {
+      agent: entry.agent,
+      kind: entry.kind,
+      timestamp: entry.timestamp,
+      rationale: entry.rationale,
+      signature: undefined,
+    };
+    const payload = { prior, entry: entryForSig };
+
+    const canonical = canonicalize(payload);
+    if (canonical === undefined) {
+      throw new Error(`Failed to canonicalize chain entry payload for agent "${entry.agent}"`);
+    }
+
+    const payloadBuf = new TextEncoder().encode(canonical);
+    const seed = new Uint8Array(keysByAgent[entry.agent]);
+    const sig = signPayload(payloadBuf, seed);
+    entry.signature = `ed25519:${base64Encode(sig)}`;
+  }
+
+  // ── Sign outer envelope ───────────────────────────────────────────────
+
+  const { signature: _, ...envelopeWithoutSig } = result;
+  const canonical = canonicalize(envelopeWithoutSig);
+  if (canonical === undefined) {
+    throw new Error("Failed to canonicalize outer envelope");
+  }
+
+  const payloadBuf = new TextEncoder().encode(canonical);
+  const fromSeed = new Uint8Array(keysByAgent[envelope.from]);
+  const outerSig = signPayload(payloadBuf, fromSeed);
+  result.signature = `ed25519:${base64Encode(outerSig)}`;
+
+  return result;
+}

--- a/packages/cli/src/lib/signEnvelope.ts
+++ b/packages/cli/src/lib/signEnvelope.ts
@@ -130,13 +130,13 @@ export function signEnvelope(
 
     // Build signing payload: { prior: chain[0..i], entry: { ...entry, signature: undefined } }
     const prior = resultChain.slice(0, i);
-    const entryForSig: ChainEntry & { signature: undefined } = {
+    const entryForSig = {
       agent: entry.agent,
       kind: entry.kind,
       timestamp: entry.timestamp,
       rationale: entry.rationale,
       signature: undefined,
-    };
+    } as const;
     const payload = { prior, entry: entryForSig };
 
     const canonical = canonicalize(payload);

--- a/packages/cli/test/signEnvelope.test.ts
+++ b/packages/cli/test/signEnvelope.test.ts
@@ -1,0 +1,304 @@
+/**
+ * signEnvelope.test.ts — Tests for signEnvelope()
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as ed from "@noble/ed25519";
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+import { signEnvelope, type Envelope, type ChainEntry } from "../src/lib/signEnvelope.js";
+
+// Wire sha512 for sync sign operations (same as production).
+import { hashes } from "@noble/ed25519";
+hashes.sha512 = (message: Uint8Array) => {
+  return new Uint8Array(createHash("sha512").update(message).digest());
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Create a 32-byte seed from a repeated hex byte (e.g., 0x01 -> 32 bytes of 0x01). */
+function seedFromByte(b: number): Buffer {
+  return Buffer.alloc(32, b);
+}
+
+/** Sign payload the same way signEnvelope does, for fixture generation. */
+function signFixture(payload: Uint8Array, seed: Buffer): string {
+  const sig = ed.sign(payload, new Uint8Array(seed));
+  return `ed25519:${Buffer.from(sig).toString("base64")}`;
+}
+
+/** Build a minimal valid envelope. */
+function makeEnvelope(overrides: Partial<Envelope> & {
+  from: string;
+  chain: ChainEntry[];
+}): Envelope {
+  return {
+    v: 1,
+    to: overrides.to ?? "anvil",
+    subject: overrides.subject ?? "Test envelope",
+    body: overrides.body ?? "Hello from test",
+    messageId: overrides.messageId ?? "msg-test-001",
+    timestamp: overrides.timestamp ?? "2026-05-24T12:00:00.000Z",
+    delegationChain: overrides.chain,
+    ...overrides,
+  };
+}
+
+// ─── Test fixtures ─────────────────────────────────────────────────────────
+
+// Flint's seed = 32 bytes of 0x01
+const FLINT_SEED = seedFromByte(0x01);
+
+// Nathan's key (not actually used for signing — human)
+const NATHAN_SEED = seedFromByte(0x02);
+
+// Sherlock's seed
+const SHERLOCK_SEED = seedFromByte(0x03);
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("signEnvelope", () => {
+  // ── Test 1: Worked-example forward path ───────────────────────────────
+
+  test("signs a Nathan→Flint envelope with correct chain + outer signatures", () => {
+    const chain: ChainEntry[] = [
+      {
+        agent: "nathan",
+        kind: "human",
+        timestamp: "2026-05-24T11:00:00.000Z",
+        rationale: "Nathan originates the request",
+        signature: null,
+      },
+      {
+        agent: "flint",
+        kind: "agent",
+        timestamp: "2026-05-24T11:05:00.000Z",
+        rationale: "Flint dispatches to anvil",
+        signature: null,
+      },
+    ];
+
+    const envelope = makeEnvelope({
+      from: "flint",
+      to: "anvil",
+      subject: "Dispatch PR-1",
+      body: "Build signEnvelope()",
+      messageId: "msg-pr1-001",
+      timestamp: "2026-05-24T11:05:00.000Z",
+      chain,
+    });
+
+    const result = signEnvelope(envelope, { flint: FLINT_SEED });
+
+    // Verify Flint's chain entry was signed
+    expect(result.delegationChain[0].signature).toBeNull(); // nathan = human
+    expect(result.delegationChain[1].signature).not.toBeNull();
+    expect(result.delegationChain[1].signature).toMatch(/^ed25519:/);
+
+    // Verify outer signature exists
+    expect(result.signature).not.toBeUndefined();
+    expect(result.signature).toMatch(/^ed25519:/);
+
+    // Verify chain entry sig is correct — recompute expected
+    const expectedChainEntryPayload = {
+      prior: [result.delegationChain[0]],
+      entry: {
+        agent: "flint",
+        kind: "agent",
+        timestamp: "2026-05-24T11:05:00.000Z",
+        rationale: "Flint dispatches to anvil",
+        signature: undefined,
+      },
+    };
+    const expectedChainSig = signFixture(
+      new TextEncoder().encode(canonicalize(expectedChainEntryPayload)!),
+      FLINT_SEED,
+    );
+    expect(result.delegationChain[1].signature).toBe(expectedChainSig);
+
+    // Verify outer sig is correct
+    const { signature: _, ...envelopeWithoutSig } = result;
+    const expectedOuterSig = signFixture(
+      new TextEncoder().encode(canonicalize(envelopeWithoutSig)!),
+      FLINT_SEED,
+    );
+    expect(result.signature).toBe(expectedOuterSig);
+
+    // Original input not mutated
+    expect(envelope.signature).toBeUndefined();
+    expect(envelope.delegationChain[0].signature).toBeNull();
+    expect(envelope.delegationChain[1].signature).toBeNull();
+  });
+
+  // ── Test 2: Sub-dispatch chain growth ─────────────────────────────────
+
+  test("preserves prior sigs when adding new chain entry (idempotent re-sign)", () => {
+    // Step 1: sign as Flint
+    const nathanEntry: ChainEntry = {
+      agent: "nathan",
+      kind: "human",
+      timestamp: "2026-05-24T11:00:00.000Z",
+      rationale: "Nathan originates",
+      signature: null,
+    };
+    const flintEntry: ChainEntry = {
+      agent: "flint",
+      kind: "agent",
+      timestamp: "2026-05-24T11:05:00.000Z",
+      rationale: "Flint signs off",
+      signature: null,
+    };
+
+    const flintSigned = signEnvelope(
+      makeEnvelope({
+        from: "flint",
+        to: "sherlock",
+        subject: "Sub-dispatch",
+        body: "Forward this",
+        messageId: "msg-chain-001",
+        chain: [nathanEntry, flintEntry],
+      }),
+      { flint: FLINT_SEED },
+    );
+
+    const flintChainSig = flintSigned.delegationChain[1].signature;
+    expect(flintChainSig).not.toBeNull();
+
+    // Step 2: Sherlock appends their entry and re-signs
+    const sherlockEntry: ChainEntry = {
+      agent: "sherlock",
+      kind: "agent",
+      timestamp: "2026-05-24T11:10:00.000Z",
+      rationale: "Sherlock reviews and forwards to anvil",
+      signature: null,
+    };
+
+    const result = signEnvelope(
+      makeEnvelope({
+        from: "sherlock",
+        to: "anvil",
+        subject: "Sub-dispatch",
+        body: "Forward this",
+        messageId: "msg-chain-001",
+        chain: [...flintSigned.delegationChain, sherlockEntry],
+      }),
+      { flint: FLINT_SEED, sherlock: SHERLOCK_SEED },
+    );
+
+    // Flint's prior sig preserved unchanged
+    expect(result.delegationChain[1].signature).toBe(flintChainSig);
+
+    // Sherlock's entry now signed
+    expect(result.delegationChain[2].signature).not.toBeNull();
+    expect(result.delegationChain[2].signature).toMatch(/^ed25519:/);
+
+    // Verify Sherlock's chain entry sig
+    const expectedSherlockSig = signFixture(
+      new TextEncoder().encode(
+        canonicalize({
+          prior: result.delegationChain.slice(0, 2),
+          entry: {
+            agent: "sherlock",
+            kind: "agent",
+            timestamp: "2026-05-24T11:10:00.000Z",
+            rationale: "Sherlock reviews and forwards to anvil",
+            signature: undefined,
+          },
+        })!,
+      ),
+      SHERLOCK_SEED,
+    );
+    expect(result.delegationChain[2].signature).toBe(expectedSherlockSig);
+
+    // Outer sig uses Sherlock's key
+    expect(result.signature).not.toBeUndefined();
+  });
+
+  // ── Test 3: Throws on chain tip mismatch ──────────────────────────────
+
+  test("throws when envelope.from does not match chain tip agent", () => {
+    const chain: ChainEntry[] = [
+      {
+        agent: "sherlock",
+        kind: "agent",
+        timestamp: "2026-05-24T11:00:00.000Z",
+        rationale: "Sherlock signed",
+        signature: null,
+      },
+    ];
+
+    const envelope = makeEnvelope({
+      from: "flint", // mismatch: chain tip is sherlock
+      to: "anvil",
+      chain,
+    });
+
+    expect(() => signEnvelope(envelope, {
+      sherlock: SHERLOCK_SEED,
+      flint: FLINT_SEED,
+    })).toThrow(/from.*flint.*must equal.*chain tip.*sherlock/i);
+  });
+
+  // ── Test 4: Throws on missing privkey ─────────────────────────────────
+
+  test("throws when keysByAgent is missing a required key", () => {
+    const chain: ChainEntry[] = [
+      {
+        agent: "nathan",
+        kind: "human",
+        timestamp: "2026-05-24T11:00:00.000Z",
+        rationale: "Nathan originates",
+        signature: null,
+      },
+      {
+        agent: "flint",
+        kind: "agent",
+        timestamp: "2026-05-24T11:05:00.000Z",
+        rationale: "Flint dispatches",
+        signature: null,
+      },
+    ];
+
+    const envelope = makeEnvelope({
+      from: "flint",
+      to: "anvil",
+      chain,
+    });
+
+    // nathan is human — no key needed. But flint's key IS needed.
+    expect(() => signEnvelope(envelope, { nathan: NATHAN_SEED })).toThrow(
+      /Missing private key for agent "flint"/,
+    );
+  });
+
+  // ── Test 5: Throws on human entry with non-null signature ─────────────
+
+  test("throws when a human-kind chain entry has a non-null signature", () => {
+    const chain: ChainEntry[] = [
+      {
+        agent: "nathan",
+        kind: "human",
+        timestamp: "2026-05-24T11:00:00.000Z",
+        rationale: "Nathan originates",
+        signature: "ed25519:ZmFrZQ==", // human should NOT have a sig
+      },
+      {
+        agent: "flint",
+        kind: "agent",
+        timestamp: "2026-05-24T11:05:00.000Z",
+        rationale: "Flint dispatches",
+        signature: null,
+      },
+    ];
+
+    const envelope = makeEnvelope({
+      from: "flint",
+      to: "anvil",
+      chain,
+    });
+
+    expect(() => signEnvelope(envelope, { flint: FLINT_SEED })).toThrow(
+      /Human-kind chain entry.*nathan.*must have null signature/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements `signEnvelope()` in `@tpsdev-ai/cli` per the [TPS Signed Envelopes](https://github.com/tpsdev-ai/cli/blob/main/specs/TPS-SIGNED-ENVELOPES.md) spec (PR-1 / ops-cgud).

### What it does

- Signs every agent-kind entry in the delegation chain whose signature is null/missing
- Signs the outer envelope using the last chain entry's private key
- Uses JCS (RFC 8785) canonicalization via `canonicalize` for deterministic byte-level signing
- Uses `@noble/ed25519` for signing (already a dependency)
- Idempotent re-signing: preserves existing signatures (for PR-3 mail forwarding)

### Tests (5)

1. **Forward path** — Nathan→Flint envelope, verifies chain entry sig + outer sig match known keys
2. **Chain growth** — Signed Nathan→Flint, then Sherlock appends + re-signs, prior sigs preserved
3. **Chain tip mismatch** — from="flint" but tip="sherlock" throws
4. **Missing privkey** — Human entry okay without key, agent entry missing key throws
5. **Human entry with sig** — Throws on human-kind entry with non-null signature

### Anti-patterns avoided

- No verifyEnvelope() (PR-2)
- No mail-send wiring (PR-3)
- No Flair client dependency (pure function, takes keysByAgent)
- No mutation of input (deep clones)

**Beads:** ops-cgud (parent epic ops-9cyb)