### PR TITLE
feat(lib): verifyEnvelope() — verify Ed25519 sigs on TPS envelope + delegation chain

### DIFF
--- a/packages/cli/src/lib/signEnvelope.ts
+++ b/packages/cli/src/lib/signEnvelope.ts
@@ -44,12 +44,46 @@ function base64Encode(buf: Uint8Array): string {
   return Buffer.from(buf).toString("base64");
 }
 
+function base64Decode(s: string): Uint8Array {
+  return new Uint8Array(Buffer.from(s, "base64"));
+}
+
 /**
  * Sign payload bytes with an Ed25519 seed (32 bytes).
  * Returns a 64-byte signature.
  */
 function signPayload(payload: Uint8Array, seed: Uint8Array): Uint8Array {
   return ed.sign(payload, seed);
+}
+
+/**
+ * Verify an Ed25519 signature against a payload and public key.
+ */
+function verifyPayload(
+  payload: Uint8Array,
+  signature: Uint8Array,
+  publicKey: Uint8Array,
+): boolean {
+  try {
+    return ed.verify(signature, payload, publicKey);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decode a "ed25519:<base64>" signature string into raw bytes.
+ * Returns null if the signature is null/undefined or malformed.
+ */
+function decodeSignature(sig: string | null | undefined): Uint8Array | null {
+  if (sig == null) return null;
+  const prefix = "ed25519:";
+  if (!sig.startsWith(prefix)) return null;
+  try {
+    return base64Decode(sig.slice(prefix.length));
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -164,4 +198,135 @@ export function signEnvelope(
   result.signature = `ed25519:${base64Encode(outerSig)}`;
 
   return result;
+}
+
+// ─── Flair client interface (dependency-injected) ──────────────────────────
+
+export interface FlairClient {
+  getAgent(name: string): Promise<{ publicKey: Buffer } | null>;
+}
+
+// ─── Verify result types ────────────────────────────────────────────────────
+
+export interface VerifyOk {
+  ok: true;
+}
+
+export interface VerifyReject {
+  ok: false;
+  reason: string;
+}
+
+/**
+ * Verify a signed envelope:
+ * - v must be 1
+ * - delegationChain must be non-empty and length <= 16
+ * - last chain entry's agent must equal envelope.from
+ * - outer signature must verify against envelope.from's pubkey over
+ *   jcs({ ...envelope, signature: undefined })
+ * - each agent-kind chain entry's signature must verify against that
+ *   agent's pubkey over jcs({ prior: chain[0..i], entry: { ...entry, signature: undefined } })
+ * - each human-kind entry must have signature === null
+ *
+ * Pure function with DI'd flairClient — no Flair HTTP coupling.
+ */
+export async function verifyEnvelope(
+  envelope: Envelope,
+  flairClient: FlairClient,
+): Promise<VerifyOk | VerifyReject> {
+  // 1. Version check
+  if (envelope.v !== 1) {
+    return { ok: false, reason: "unsupported version" };
+  }
+
+  // 2. Chain must exist and be non-empty
+  const chain = envelope.delegationChain;
+  if (!chain || chain.length === 0) {
+    return { ok: false, reason: "missing chain" };
+  }
+
+  // 3. Chain length limit
+  if (chain.length > 16) {
+    return { ok: false, reason: "chain too long" };
+  }
+
+  // 4. Chain tip must match envelope.from
+  if (chain[chain.length - 1].agent !== envelope.from) {
+    return { ok: false, reason: "chain tip / from mismatch" };
+  }
+
+  // 5. Human entries must have null signature
+  for (const entry of chain) {
+    if (entry.kind === "human" && entry.signature !== null) {
+      return { ok: false, reason: "human entry must have null signature" };
+    }
+  }
+
+  // 6. Resolve all agent pubkeys from Flair
+  const pubkeys = new Map<string, Buffer>();
+  const agentsToResolve = new Set<string>();
+  for (const entry of chain) {
+    if (entry.kind === "agent") agentsToResolve.add(entry.agent);
+  }
+  agentsToResolve.add(envelope.from);
+
+  for (const agent of agentsToResolve) {
+    const info = await flairClient.getAgent(agent);
+    if (!info) {
+      return { ok: false, reason: `agent ${agent} not found in Flair` };
+    }
+    pubkeys.set(agent, info.publicKey);
+  }
+
+  // 7. Verify each agent-kind chain entry signature
+  for (let i = 0; i < chain.length; i++) {
+    const entry = chain[i];
+    if (entry.kind !== "agent") continue;
+
+    const sigBytes = decodeSignature(entry.signature);
+    if (!sigBytes) {
+      return { ok: false, reason: `chain entry ${i} signature invalid` };
+    }
+
+    const prior = chain.slice(0, i);
+    const entryForSig = {
+      agent: entry.agent,
+      kind: entry.kind,
+      timestamp: entry.timestamp,
+      rationale: entry.rationale,
+      signature: undefined,
+    } as const;
+    const payload = { prior, entry: entryForSig };
+
+    const canonical = canonicalize(payload);
+    if (canonical === undefined) {
+      return { ok: false, reason: `chain entry ${i} signature invalid` };
+    }
+
+    const payloadBuf = new TextEncoder().encode(canonical);
+    const pubKey = pubkeys.get(entry.agent)!;
+    if (!verifyPayload(payloadBuf, sigBytes, new Uint8Array(pubKey))) {
+      return { ok: false, reason: `chain entry ${i} signature invalid` };
+    }
+  }
+
+  // 8. Verify outer signature
+  const sigBytes = decodeSignature(envelope.signature);
+  if (!sigBytes) {
+    return { ok: false, reason: "outer signature invalid" };
+  }
+
+  const { signature: _, ...envelopeWithoutSig } = envelope;
+  const canonical = canonicalize(envelopeWithoutSig);
+  if (canonical === undefined) {
+    return { ok: false, reason: "outer signature invalid" };
+  }
+
+  const payloadBuf = new TextEncoder().encode(canonical);
+  const fromPubKey = pubkeys.get(envelope.from)!;
+  if (!verifyPayload(payloadBuf, sigBytes, new Uint8Array(fromPubKey))) {
+    return { ok: false, reason: "outer signature invalid" };
+  }
+
+  return { ok: true };
 }

--- a/packages/cli/test/verifyEnvelope.test.ts
+++ b/packages/cli/test/verifyEnvelope.test.ts
@@ -1,0 +1,350 @@
+/**
+ * verifyEnvelope.test.ts — Tests for verifyEnvelope()
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as ed from "@noble/ed25519";
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+import {
+  signEnvelope,
+  verifyEnvelope,
+  type Envelope,
+  type ChainEntry,
+  type FlairClient,
+} from "../src/lib/signEnvelope.js";
+
+// Wire sha512 for sync sign operations (same as production).
+import { hashes } from "@noble/ed25519";
+hashes.sha512 = (message: Uint8Array) => {
+  return new Uint8Array(createHash("sha512").update(message).digest());
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function seedFromByte(b: number): Buffer {
+  return Buffer.alloc(32, b);
+}
+
+/** Derive public key from seed (32 bytes). */
+function pubkeyFromSeed(seed: Buffer): Buffer {
+  return Buffer.from(ed.getPublicKey(new Uint8Array(seed)));
+}
+
+/** Build a mock FlairClient from a map of seed bytes. */
+function mockFlair(agentSeeds: Record<string, Buffer>): FlairClient {
+  const pubs: Record<string, Buffer> = {};
+  for (const [name, seed] of Object.entries(agentSeeds)) {
+    pubs[name] = pubkeyFromSeed(seed);
+  }
+  return {
+    async getAgent(name: string) {
+      const pk = pubs[name];
+      return pk ? { publicKey: pk } : null;
+    },
+  };
+}
+
+function makeEnvelope(overrides: Partial<Envelope> & {
+  from: string;
+  chain: ChainEntry[];
+}): Envelope {
+  return {
+    v: 1,
+    to: overrides.to ?? "anvil",
+    subject: overrides.subject ?? "Test envelope",
+    body: overrides.body ?? "Hello from test",
+    messageId: overrides.messageId ?? "msg-test-001",
+    timestamp: overrides.timestamp ?? "2026-05-24T12:00:00.000Z",
+    delegationChain: overrides.chain,
+    ...overrides,
+  };
+}
+
+// ─── Test fixtures ─────────────────────────────────────────────────────────
+
+const FLINT_SEED = seedFromByte(0x01);
+const SHERLOCK_SEED = seedFromByte(0x03);
+const RESEARCH_SEED = seedFromByte(0x04);
+const ATTACKER_SEED = seedFromByte(0xff);
+
+const FLINT_PUB = pubkeyFromSeed(FLINT_SEED);
+const SHERLOCK_PUB = pubkeyFromSeed(SHERLOCK_SEED);
+const RESEARCH_PUB = pubkeyFromSeed(RESEARCH_SEED);
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("verifyEnvelope", () => {
+  // ── Test 1: Happy path ────────────────────────────────────────────────
+
+  test("verifies a signed envelope (Nathan→Flint) returns ok:true", async () => {
+    const chain: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: null },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const envelope = makeEnvelope({ from: "flint", to: "anvil", chain });
+    const signed = signEnvelope(envelope, { flint: FLINT_SEED });
+
+    const result = await verifyEnvelope(signed, mockFlair({ flint: FLINT_SEED }));
+    expect(result).toEqual({ ok: true });
+  });
+
+  // ── Test 2: 3-hop chain ───────────────────────────────────────────────
+
+  test("verifies a 3-hop signed chain (Nathan→Flint→Sherlock→research-agent)", async () => {
+    // Hop 1: Nathan→Flint
+    const chain1: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: null },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const e1 = signEnvelope(makeEnvelope({ from: "flint", to: "sherlock", messageId: "hop1", chain: chain1 }), { flint: FLINT_SEED });
+
+    // Hop 2: Flint→Sherlock (re-signs with Sherlock's key)
+    const chain2: ChainEntry[] = [
+      ...e1.delegationChain,
+      { agent: "sherlock", kind: "agent", timestamp: "2026-05-24T11:10:00.000Z", rationale: "Reviews", signature: null },
+    ];
+    const e2 = signEnvelope(makeEnvelope({ from: "sherlock", to: "research-agent", messageId: "hop2", chain: chain2 }), { flint: FLINT_SEED, sherlock: SHERLOCK_SEED });
+
+    // Hop 3: Sherlock→research-agent (re-signs with research-agent's key)
+    const chain3: ChainEntry[] = [
+      ...e2.delegationChain,
+      { agent: "research-agent", kind: "agent", timestamp: "2026-05-24T11:15:00.000Z", rationale: "Researches", signature: null },
+    ];
+    const e3 = signEnvelope(makeEnvelope({ from: "research-agent", to: "anvil", messageId: "hop3", chain: chain3 }), {
+      flint: FLINT_SEED,
+      sherlock: SHERLOCK_SEED,
+      "research-agent": RESEARCH_SEED,
+    });
+
+    const result = await verifyEnvelope(e3, mockFlair({
+      flint: FLINT_SEED,
+      sherlock: SHERLOCK_SEED,
+      "research-agent": RESEARCH_SEED,
+    }));
+    expect(result).toEqual({ ok: true });
+  });
+
+  // ── Test 3: Forged sender ─────────────────────────────────────────────
+
+  test("rejects forged sender (from changed without re-signing)", async () => {
+    const chain: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: null },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const signed = signEnvelope(makeEnvelope({ from: "flint", to: "anvil", chain }), { flint: FLINT_SEED });
+
+    // Forge: replace from + chain tip agent with "attacker", keep flint's sigs.
+    // Chain entry 1 sig was computed over { entry: { agent: "flint", ... } }
+    // but the entry now reads "attacker" — chain entry sig fails first.
+    const forgedChain = [...signed.delegationChain];
+    forgedChain[1] = { ...forgedChain[1], agent: "attacker" };
+    const forged = { ...signed, from: "attacker", delegationChain: forgedChain };
+
+    const result = await verifyEnvelope(forged, mockFlair({
+      flint: FLINT_SEED,
+      attacker: ATTACKER_SEED,
+    }));
+    expect(result).toEqual({ ok: false, reason: "chain entry 1 signature invalid" });
+  });
+
+  // ── Test 4: Chain truncation ──────────────────────────────────────────
+
+  test("rejects truncated chain (dropped entry, inner sig becomes invalid)", async () => {
+    // Sign with 2 entries in chain (nathan + flint)
+    const chain: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: null },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const signed = signEnvelope(makeEnvelope({ from: "flint", to: "anvil", chain }), { flint: FLINT_SEED });
+
+    // Truncate: drop nathan entry and re-sign outer with flint's key
+    // Flint's chain entry sig was over (nathan-only prior + flint),
+    // but now prior is empty (since nathan was dropped).
+    const truncatedChain = [signed.delegationChain[1]]; // just flint
+    const truncated = { ...signed, delegationChain: truncatedChain };
+
+    // Re-sign outer to make it valid; inner flint sig is now wrong
+    const { signature: _, ...envWithoutSig } = truncated;
+    const newOuterCanonical = canonicalize(envWithoutSig);
+    const { sign } = await import("@noble/ed25519");
+    const newOuterSig = sign(
+      new TextEncoder().encode(newOuterCanonical!),
+      new Uint8Array(FLINT_SEED),
+    );
+
+    const tampered = {
+      ...truncated,
+      signature: `ed25519:${Buffer.from(newOuterSig).toString("base64")}`,
+    };
+
+    const result = await verifyEnvelope(tampered, mockFlair({ flint: FLINT_SEED }));
+    expect(result).toEqual({ ok: false, reason: "chain entry 0 signature invalid" });
+  });
+
+  // ── Test 5: Chain injection ───────────────────────────────────────────
+
+  test("rejects injected fake entry in middle of chain", async () => {
+    // Original: nathan→flint (2 entries)
+    const chain: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: null },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const signed = signEnvelope(makeEnvelope({ from: "flint", to: "anvil", chain }), { flint: FLINT_SEED });
+
+    // Inject fake sherlock entry between nathan and flint
+    const fakeEntry: ChainEntry = {
+      agent: "sherlock",
+      kind: "agent",
+      timestamp: "2026-05-24T11:03:00.000Z",
+      rationale: "Fake review",
+      signature: "ed25519:AAAA", // bogus sig
+    };
+    const injectedChain = [signed.delegationChain[0], fakeEntry, signed.delegationChain[1]];
+    const injected = { ...signed, delegationChain: injectedChain };
+
+    const result = await verifyEnvelope(injected, mockFlair({
+      flint: FLINT_SEED,
+      sherlock: SHERLOCK_SEED,
+    }));
+    // Either flint's entry sig (index 2) or sherlock's fake sig (index 1) fails first —
+    // sherlock's fake sig at entry 1 should fail since "ed25519:AAAA" is bogus
+    expect(result.ok).toBe(false);
+    expect(result).toHaveProperty("reason");
+  });
+
+  // ── Test 6: Adjacent-hop reorder ──────────────────────────────────────
+
+  test("rejects reordered chain entries (swapped hops)", async () => {
+    // Build 3-hop chain: nathan(human) → flint → sherlock
+    const chain1: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: null },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const e1 = signEnvelope(makeEnvelope({ from: "flint", to: "sherlock", messageId: "reorder", chain: chain1 }), { flint: FLINT_SEED });
+
+    const chain2: ChainEntry[] = [
+      ...e1.delegationChain,
+      { agent: "sherlock", kind: "agent", timestamp: "2026-05-24T11:10:00.000Z", rationale: "Reviews", signature: null },
+    ];
+    const e2 = signEnvelope(makeEnvelope({ from: "sherlock", to: "anvil", messageId: "reorder", chain: chain2 }), {
+      flint: FLINT_SEED, sherlock: SHERLOCK_SEED,
+    });
+
+    // Swap flint (index 1) and sherlock (index 2); update from to match new chain tip
+    const reorderedChain = [
+      e2.delegationChain[0], // nathan
+      e2.delegationChain[2], // sherlock (was at 2, now at 1)
+      e2.delegationChain[1], // flint (was at 1, now at 2 — new chain tip)
+    ];
+    const reordered = { ...e2, from: "flint", delegationChain: reorderedChain };
+
+    const result = await verifyEnvelope(reordered, mockFlair({
+      flint: FLINT_SEED, sherlock: SHERLOCK_SEED,
+    }));
+    // sherlock's sig was over (nathan + flint + sherlock_no_sig), but
+    // now in position 1, prior is [nathan] — sig mismatch
+    expect(result.ok).toBe(false);
+    expect(result).toHaveProperty("reason");
+    // The reason pattern should be "chain entry 1 signature invalid" or similar
+    if (result.ok === false) {
+      expect(result.reason).toMatch(/chain entry \d+ signature invalid/);
+    }
+  });
+
+  // ── Test 7: Tampered rationale ────────────────────────────────────────
+
+  test("rejects tampered rationale in a prior entry", async () => {
+    const chain: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: null },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const signed = signEnvelope(makeEnvelope({ from: "flint", to: "anvil", chain }), { flint: FLINT_SEED });
+
+    // Tamper: change flint's rationale after signing
+    const tamperedChain = [...signed.delegationChain];
+    tamperedChain[1] = { ...tamperedChain[1], rationale: "I am an imposter" };
+    const tampered = { ...signed, delegationChain: tamperedChain };
+
+    const result = await verifyEnvelope(tampered, mockFlair({ flint: FLINT_SEED }));
+    expect(result).toEqual({ ok: false, reason: "chain entry 1 signature invalid" });
+  });
+
+  // ── Test 8: Message swap ──────────────────────────────────────────────
+
+  test("rejects swapped body (outer sig invalid)", async () => {
+    const chain: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: null },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const signed = signEnvelope(makeEnvelope({
+      from: "flint", to: "anvil", body: "Build signEnvelope()", chain,
+    }), { flint: FLINT_SEED });
+
+    // Swap the body
+    const swapped = { ...signed, body: "DELETE ALL THE THINGS" };
+
+    const result = await verifyEnvelope(swapped, mockFlair({ flint: FLINT_SEED }));
+    expect(result).toEqual({ ok: false, reason: "outer signature invalid" });
+  });
+
+  // ── Test 9: Chain too long ────────────────────────────────────────────
+
+  test("rejects chain with 17 hops", async () => {
+    // Build a 17-hop chain of agent entries
+    const chain: ChainEntry[] = [];
+    for (let i = 0; i < 17; i++) {
+      chain.push({
+        agent: `agent-${i}`,
+        kind: "agent",
+        timestamp: new Date(Date.UTC(2026, 4, 24, 11, i)).toISOString(),
+        rationale: `Hop ${i}`,
+        signature: null,
+      });
+    }
+
+    const envelope = makeEnvelope({ from: "agent-16", to: "anvil", chain });
+
+    const result = await verifyEnvelope(envelope, mockFlair({}));
+    expect(result).toEqual({ ok: false, reason: "chain too long" });
+  });
+
+  // ── Test 10: Agent not in Flair ───────────────────────────────────────
+
+  test("rejects when agent pubkey is not in Flair", async () => {
+    const chain: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: null },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const signed = signEnvelope(makeEnvelope({ from: "flint", to: "anvil", chain }), { flint: FLINT_SEED });
+
+    // flairClient has no keys at all
+    const result = await verifyEnvelope(signed, mockFlair({}));
+    expect(result).toEqual({ ok: false, reason: "agent flint not found in Flair" });
+  });
+
+  // ── Test 11: Human entry with non-null signature ──────────────────────
+
+  test("rejects human entry with non-null signature", async () => {
+    const chain: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: "ed25519:ZmFrZQ==" },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const envelope = makeEnvelope({ from: "flint", to: "anvil", chain });
+
+    const result = await verifyEnvelope(envelope, mockFlair({ flint: FLINT_SEED }));
+    expect(result).toEqual({ ok: false, reason: "human entry must have null signature" });
+  });
+
+  // ── Test 12: Unsupported version ──────────────────────────────────────
+
+  test("rejects envelope with v=2", async () => {
+    const chain: ChainEntry[] = [
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const envelope = makeEnvelope({ v: 2, from: "flint", to: "anvil", chain });
+
+    const result = await verifyEnvelope(envelope, mockFlair({ flint: FLINT_SEED }));
+    expect(result).toEqual({ ok: false, reason: "unsupported version" });
+  });
+});


### PR DESCRIPTION
## Summary

Implements `verifyEnvelope()` in `@tpsdev-ai/cli` per the [TPS Signed Envelopes](https://github.com/tpsdev-ai/cli/blob/main/specs/TPS-SIGNED-ENVELOPES.md) spec (PR-2 / ops-kj1s).

Builds on PR-1 (`signEnvelope`, merged in #304).

### What it does

- Async function with dependency-injected `FlairClient` for pubkey resolution
- Verifies: version (v=1 only), chain non-empty + ≤16 entries, chain tip / from match, human entries have null sigs, chain entry sigs, outer sig
- Short-circuits on first failure with specific reason strings
- Uses same JCS canonicalization + Ed25519 wiring as `signEnvelope`

### Tests (12)

1. **Happy path** — sign then verify, returns `{ ok: true }`
2. **3-hop chain** — Nathan→Flint→Sherlock→research-agent, all sigs verify
3. **Forged sender** — change from + chain tip agent without re-signing → `chain entry 1 signature invalid`
4. **Chain truncation** — drop nathan entry, re-sign outer, inner sig fails → `chain entry 0 signature invalid`
5. **Chain injection** — insert fake entry between nathan and flint → bogus sig caught
6. **Adjacent-hop reorder** — swap flint and sherlock → prior-slice mismatch caught
7. **Tampered rationale** — change flint's rationale after signing → `chain entry 1 signature invalid`
8. **Message swap** — replace body → `outer signature invalid`
9. **Chain too long** — 17-hop chain → `chain too long`
10. **Agent not in Flair** — missing pubkey → `agent flint not found in Flair`
11. **Human entry with sig** → `human entry must have null signature`
12. **Unsupported version** — v=2 → `unsupported version`

### Anti-patterns avoided

- No mail-send wiring (PR-3)
- No Flair HTTP coupling (FlairClient is DI'd)
- No sync function (async per FlairClient.getAgent contract)
- TSC clean before push

**Beads:** ops-kj1s (parent epic ops-9cyb)