### PR TITLE
feat(mail): wire signEnvelope into tps mail send (PR-3) [ops-0rvn]

### DIFF
--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -9,6 +9,9 @@ import { loadHostIdentityId } from "../utils/identity.js";
 import { queueOutboxMessage } from "../utils/outbox.js";
 import { galLookup } from "../utils/gal.js";
 import { parseTaskEnvelope, formatTaskEnvelope, createTaskEnvelope } from "../utils/task-envelope.js";
+import { signEnvelope, type Envelope } from "../lib/signEnvelope.js";
+import { readAgentPrivateKey, parseInboundChain } from "../utils/agent-keys.js";
+import { randomUUID } from "node:crypto";
 
 interface MailArgs {
   action: "send" | "check" | "list" | "stats" | "log" | "read" | "watch" | "search" | "relay" | "topic" | "subscribe" | "unsubscribe" | "publish" | "ack" | "nack" | "gc";
@@ -184,6 +187,55 @@ export async function runMail(args: MailArgs): Promise<void> {
           console.log(`Message sent to branch office ${to}`);
         }
         return;
+      }
+
+      // Direct Maildir send: sign envelope before writing (PR-3).
+      // Best-effort: sign if the agent's private key is available;
+      // fall back to unsigned send with a warning for backward compat.
+      const privkey = readAgentPrivateKey(from);
+      if (privkey) {
+        const priorChain = parseInboundChain(process.env.TPS_INBOUND_CHAIN_JSON);
+        const hopRationale = process.env.TPS_CHAIN_RATIONALE ?? `agent ${from} tps mail send`;
+        const now = new Date().toISOString();
+
+        const chain = priorChain ?? [
+          {
+            agent: "system",
+            kind: "human" as const,
+            timestamp: now,
+            rationale: "tps mail send (no inbound chain)",
+            signature: null,
+          },
+        ];
+
+        chain.push({
+          agent: from,
+          kind: "agent" as const,
+          timestamp: now,
+          rationale: hopRationale,
+          signature: null, // signEnvelope will fill
+        });
+
+        const envelope: Envelope = {
+          v: 1,
+          from,
+          to,
+          subject: `mail to ${to}`,
+          body: args.message,
+          messageId: randomUUID(),
+          timestamp: now,
+          delegationChain: chain,
+        };
+
+        const signed = signEnvelope(envelope, { [from]: privkey });
+        const signedEnvelopeBody = JSON.stringify(signed);
+        args.message = signedEnvelopeBody;
+      } else {
+        console.warn(
+          `No private key found for agent "${from}" — sending unsigned. ` +
+          `Place a 32-byte Ed25519 seed at ~/.flair/keys/${from}.key or set ` +
+          `TPS_TEST_KEYS_DIR to enable envelope signing.`,
+        );
       }
 
       const msg = sendMessage(to, args.message, from);

--- a/packages/cli/src/utils/agent-keys.ts
+++ b/packages/cli/src/utils/agent-keys.ts
@@ -1,0 +1,58 @@
+/**
+ * agent-keys.ts — Read Ed25519 private key seeds for TPS agents.
+ *
+ * Keys are stored as 32-byte raw seeds in ~/.flair/keys/<agent>.key
+ * (mode 0600). For tests, TPS_TEST_KEYS_DIR overrides the key directory.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+function keysDir(): string {
+  if (process.env.TPS_TEST_KEYS_DIR) {
+    return process.env.TPS_TEST_KEYS_DIR;
+  }
+  return join(homedir(), ".flair", "keys");
+}
+
+/**
+ * Read an agent's Ed25519 private key seed (32 bytes).
+ * Returns null if the key file doesn't exist.
+ */
+export function readAgentPrivateKey(agentName: string): Buffer | null {
+  const path = join(keysDir(), `${agentName}.key`);
+  if (!existsSync(path)) return null;
+  return readFileSync(path);
+}
+
+/**
+ * Parse TPS_INBOUND_CHAIN_JSON into a ChainEntry array.
+ * Returns null if unset, empty, or invalid.
+ */
+import type { ChainEntry } from "../lib/signEnvelope.js";
+
+export function parseInboundChain(raw: string | undefined): ChainEntry[] | null {
+  if (!raw || raw.trim() === "") return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    // Basic shape validation: every entry must have agent, kind, timestamp, rationale
+    for (const entry of parsed) {
+      if (
+        typeof entry !== "object" ||
+        typeof entry.agent !== "string" ||
+        typeof entry.kind !== "string" ||
+        typeof entry.timestamp !== "string" ||
+        typeof entry.rationale !== "string"
+      ) {
+        return null;
+      }
+      if (entry.kind !== "human" && entry.kind !== "agent") return null;
+      if (entry.signature !== null && entry.signature !== undefined && typeof entry.signature !== "string") return null;
+    }
+    return parsed as ChainEntry[];
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/test/mail-send-sign.test.ts
+++ b/packages/cli/test/mail-send-sign.test.ts
@@ -1,0 +1,197 @@
+/**
+ * mail-send-sign.test.ts — Tests for signed-envelope mail send (PR-3)
+ */
+
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, readdirSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import * as ed from "@noble/ed25519";
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+import {
+  verifyEnvelope,
+  signEnvelope,
+  type Envelope,
+  type ChainEntry,
+} from "../src/lib/signEnvelope.js";
+
+// Wire sha512 for sync sign operations.
+import { hashes } from "@noble/ed25519";
+hashes.sha512 = (message: Uint8Array) => {
+  return new Uint8Array(createHash("sha512").update(message).digest());
+};
+
+const TPS_BIN = resolve(import.meta.dir, "../bin/tps.ts");
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function seedFromByte(b: number): Buffer {
+  return Buffer.alloc(32, b);
+}
+
+function pubkeyFromSeed(seed: Buffer): Buffer {
+  return Buffer.from(ed.getPublicKey(new Uint8Array(seed)));
+}
+
+function mockFlair(agentSeeds: Record<string, Buffer>) {
+  const pubs: Record<string, Buffer> = {};
+  for (const [name, s] of Object.entries(agentSeeds)) {
+    pubs[name] = pubkeyFromSeed(s);
+  }
+  return {
+    async getAgent(name: string) {
+      const pk = pubs[name];
+      return pk ? { publicKey: pk } : null;
+    },
+  };
+}
+
+function runMailSend(args: string[], env: Record<string, string>) {
+  const home = env.HOME ?? join(env.TPS_MAIL_DIR ? join(env.TPS_MAIL_DIR, "..") : tmpdir(), "home");
+  mkdirSync(home, { recursive: true });
+  return spawnSync("bun", [TPS_BIN, "mail", "send", ...args], {
+    encoding: "utf-8",
+    cwd: tmpdir(),
+    env: { ...process.env, HOME: home, ...env },
+  });
+}
+
+function readSentEnvelope(mailDir: string, recipient: string): Envelope | null {
+  const newDir = join(mailDir, recipient, "new");
+  try {
+    const files = readdirSync(newDir).filter((f) => f.endsWith(".json"));
+    if (files.length === 0) return null;
+    const msg = JSON.parse(readFileSync(join(newDir, files[0]!), "utf-8"));
+    return JSON.parse(msg.body) as Envelope;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Test fixtures ─────────────────────────────────────────────────────────
+
+const FLINT_SEED = seedFromByte(0x01);
+const SHERLOCK_SEED = seedFromByte(0x03);
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("tps mail send with signed envelopes", () => {
+  let tempRoot: string;
+  let keysDir: string;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), "tps-sign-send-"));
+    keysDir = join(tempRoot, "keys");
+    mkdirSync(keysDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  // ── Test 1: No inbound chain ──────────────────────────────────────────
+
+  test("signs envelope with fresh chain when TPS_INBOUND_CHAIN_JSON is unset", async () => {
+    const mailDir = join(tempRoot, "mail");
+    writeFileSync(join(keysDir, "flint.key"), FLINT_SEED);
+
+    const result = runMailSend(["anvil", "Build PR-3"], {
+      TPS_MAIL_DIR: mailDir,
+      TPS_AGENT_ID: "flint",
+      TPS_TEST_KEYS_DIR: keysDir,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Message sent");
+
+    const env = readSentEnvelope(mailDir, "anvil");
+    expect(env).not.toBeNull();
+    expect(env!.v).toBe(1);
+    expect(env!.from).toBe("flint");
+    expect(env!.to).toBe("anvil");
+    expect(env!.body).toBe("Build PR-3");
+    expect(env!.delegationChain.length).toBe(2);
+    expect(env!.delegationChain[0].agent).toBe("system");
+    expect(env!.delegationChain[0].kind).toBe("human");
+    expect(env!.delegationChain[0].signature).toBeNull();
+    expect(env!.delegationChain[1].agent).toBe("flint");
+    expect(env!.delegationChain[1].kind).toBe("agent");
+    expect(env!.delegationChain[1].signature).toMatch(/^ed25519:/);
+    expect(env!.signature).toMatch(/^ed25519:/);
+
+    // Verify
+    const vr = await verifyEnvelope(env!, mockFlair({ flint: FLINT_SEED }));
+    expect(vr).toEqual({ ok: true });
+  });
+
+  // ── Test 2: With inbound chain ────────────────────────────────────────
+
+  test("appends to inbound chain and signs new hop", async () => {
+    const mailDir = join(tempRoot, "mail");
+    writeFileSync(join(keysDir, "flint.key"), FLINT_SEED);
+    writeFileSync(join(keysDir, "sherlock.key"), SHERLOCK_SEED);
+
+    // Pre-sign a Flint envelope as the inbound chain
+    const priorChain: ChainEntry[] = [
+      { agent: "nathan", kind: "human", timestamp: "2026-05-24T11:00:00.000Z", rationale: "Originates", signature: null },
+      { agent: "flint", kind: "agent", timestamp: "2026-05-24T11:05:00.000Z", rationale: "Dispatches", signature: null },
+    ];
+    const priorSigned = signEnvelope(
+      { v: 1, from: "flint", to: "sherlock", body: "Review PR-1", messageId: "prior-001", timestamp: "2026-05-24T11:05:00.000Z", delegationChain: priorChain },
+      { flint: FLINT_SEED },
+    );
+    const inboundChainJson = JSON.stringify(priorSigned.delegationChain);
+
+    // Now send as sherlock with the inbound chain
+    const result = runMailSend(["sherlock", "Forwarding to anvil"], {
+      TPS_MAIL_DIR: mailDir,
+      TPS_AGENT_ID: "sherlock",
+      TPS_TEST_KEYS_DIR: keysDir,
+      TPS_INBOUND_CHAIN_JSON: inboundChainJson,
+    });
+
+    expect(result.status).toBe(0);
+
+    const env = readSentEnvelope(mailDir, "sherlock");
+    expect(env).not.toBeNull();
+    // Chain should have 3 entries: nathan, flint, sherlock
+    expect(env!.delegationChain.length).toBe(3);
+    expect(env!.delegationChain[0].agent).toBe("nathan");
+    expect(env!.delegationChain[1].agent).toBe("flint");
+    expect(env!.delegationChain[2].agent).toBe("sherlock");
+    expect(env!.from).toBe("sherlock");
+
+    // Flint's prior sig should be preserved
+    expect(env!.delegationChain[1].signature).toBe(priorSigned.delegationChain[1].signature);
+
+    // All sigs verify
+    const vr = await verifyEnvelope(env!, mockFlair({ flint: FLINT_SEED, sherlock: SHERLOCK_SEED }));
+    expect(vr).toEqual({ ok: true });
+  });
+
+  // ── Test 3: Custom rationale ──────────────────────────────────────────
+
+  test("uses TPS_CHAIN_RATIONALE in the current hop entry", async () => {
+    const mailDir = join(tempRoot, "mail");
+    writeFileSync(join(keysDir, "flint.key"), FLINT_SEED);
+
+    const result = runMailSend(["anvil", "With rationale"], {
+      TPS_MAIL_DIR: mailDir,
+      TPS_AGENT_ID: "flint",
+      TPS_TEST_KEYS_DIR: keysDir,
+      TPS_CHAIN_RATIONALE: "K&S dispatch on bob#42",
+    });
+
+    expect(result.status).toBe(0);
+
+    const env = readSentEnvelope(mailDir, "anvil");
+    expect(env).not.toBeNull();
+    expect(env!.delegationChain[1].rationale).toBe("K&S dispatch on bob#42");
+    expect(env!.delegationChain[1].signature).toMatch(/^ed25519:/);
+
+    const vr = await verifyEnvelope(env!, mockFlair({ flint: FLINT_SEED }));
+    expect(vr).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## What

Wires `signEnvelope()` into `tps mail send` so every direct Maildir send is signed with Ed25519 before write. This is the **SEND** side. Consumer strict verification is PR-4.

Builds on:
- PR-1: `signEnvelope()` (merged `d02251b`)
- PR-2: `verifyEnvelope()` (merged `7c2fe89`)

## Changes

### New file: `packages/cli/src/utils/agent-keys.ts`
- `readAgentPrivateKey(agentName)` — reads 32-byte Ed25519 seed from `~/.flair/keys/<agent>.key` (override with `TPS_TEST_KEYS_DIR`)
- `parseInboundChain(raw)` — parses `TPS_INBOUND_CHAIN_JSON` into `ChainEntry[]`, returns null if absent/invalid

### Modified: `packages/cli/src/commands/mail.ts`
After the branch/remote/bridge checks resolve to direct send, the signing block:
1. Reads the sender's private key
2. Parses `TPS_INBOUND_CHAIN_JSON` for prior chain
3. Respects `TPS_CHAIN_RATIONALE` for the hop rationale
4. Appends current agent as a new chain entry
5. Calls `signEnvelope()` with the key map
6. Writes the signed envelope as the message body
7. Falls back to unsigned send (with warning) if no key is available

### New file: `packages/cli/test/mail-send-sign.test.ts`
3 integration tests:
1. **No inbound chain** — fresh 2-entry chain (system human + agent), verifies ok
2. **With inbound chain** — 3-entry chain (nathan/flint/sherlock), prior sigs preserved, verifies ok
3. **Custom rationale** — `TPS_CHAIN_RATIONALE` appears in the current hop entry

## Design decisions

- **Best-effort, not mandatory.** If no private key is found, the send falls back to unsigned with a console warning. This keeps backward compat with existing tests and early-stage setups. Once all agents have keys, signing is transparent.
- **Branch/remote/bridge paths are untouched.** They use their own transport layers (outbox, websocket, sandbox delivery). Signing only applies to direct Maildir writes.
- **Env var resolution stays at the call site.** `signEnvelope()` remains pure — no env var reading inside the crypto function.

## Verification

```
bun run build     => PASS
npx tsc --noEmit  => PASS
bun test          => 1003 pass, 0 fail
```
