### PR TITLE
fix(mail): lift signEnvelope above branch-office early-return (ops-pfy6)

### DIFF
--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -9,7 +9,7 @@ import { loadHostIdentityId } from "../utils/identity.js";
 import { queueOutboxMessage } from "../utils/outbox.js";
 import { galLookup } from "../utils/gal.js";
 import { parseTaskEnvelope, formatTaskEnvelope, createTaskEnvelope } from "../utils/task-envelope.js";
-import { signEnvelope, type Envelope } from "../lib/signEnvelope.js";
+import { signEnvelope, type Envelope, type ChainEntry } from "../lib/signEnvelope.js";
 import { readAgentPrivateKey, parseInboundChain } from "../utils/agent-keys.js";
 import { randomUUID } from "node:crypto";
 
@@ -91,6 +91,59 @@ function validateAgent(agent?: string): string {
   return agent;
 }
 
+// Sign the outbound body if a private key is available for `from`.
+// Returns the JSON-stringified signed envelope, or the original body
+// (with warning) when no key is present. Called once before route
+// dispatch so all delivery paths (branch-mode outbox, remote-branch,
+// branch-office bridge, direct maildir) ship signed bodies.
+function maybeSignEnvelopeBody(from: string, to: string, body: string): string {
+  const privkey = readAgentPrivateKey(from);
+  if (!privkey) {
+    console.warn(
+      `No private key found for agent "${from}" — sending unsigned. ` +
+      `Place a 32-byte Ed25519 seed at ~/.flair/keys/${from}.key or set ` +
+      `TPS_TEST_KEYS_DIR to enable envelope signing.`,
+    );
+    return body;
+  }
+
+  const priorChain = parseInboundChain(process.env.TPS_INBOUND_CHAIN_JSON);
+  const hopRationale = process.env.TPS_CHAIN_RATIONALE ?? `agent ${from} tps mail send`;
+  const now = new Date().toISOString();
+
+  const chain: ChainEntry[] = priorChain ?? [
+    {
+      agent: "system",
+      kind: "human" as const,
+      timestamp: now,
+      rationale: "tps mail send (no inbound chain)",
+      signature: null,
+    },
+  ];
+
+  chain.push({
+    agent: from,
+    kind: "agent" as const,
+    timestamp: now,
+    rationale: hopRationale,
+    signature: null, // signEnvelope will fill
+  });
+
+  const envelope: Envelope = {
+    v: 1,
+    from,
+    to,
+    subject: `mail to ${to}`,
+    body,
+    messageId: randomUUID(),
+    timestamp: now,
+    delegationChain: chain,
+  };
+
+  const signed = signEnvelope(envelope, { [from]: privkey });
+  return JSON.stringify(signed);
+}
+
 function newestJsonMtime(dir: string): string | null {
   if (!existsSync(dir)) return null;
   const newest = readdirSync(dir)
@@ -134,6 +187,12 @@ export async function runMail(args: MailArgs): Promise<void> {
       args.message = messageBody;
 
       const from = await resolveAgentId();
+
+      // Sign the envelope BEFORE route dispatch so all four delivery paths
+      // (branch-mode outbox, remote-branch, branch-office bridge, direct maildir)
+      // ship signed bodies. Previously only the direct-maildir path signed,
+      // leaving K&S/branch-office dispatches unsigned (signed-envelopes gap #1).
+      args.message = maybeSignEnvelopeBody(from, to, args.message);
 
       // Branch mode: queue outbound to be picked up by host on next connect
       const branchHostFile = join(process.env.HOME || homedir(), ".tps", "identity", "host.json");
@@ -189,55 +248,8 @@ export async function runMail(args: MailArgs): Promise<void> {
         return;
       }
 
-      // Direct Maildir send: sign envelope before writing (PR-3).
-      // Best-effort: sign if the agent's private key is available;
-      // fall back to unsigned send with a warning for backward compat.
-      const privkey = readAgentPrivateKey(from);
-      if (privkey) {
-        const priorChain = parseInboundChain(process.env.TPS_INBOUND_CHAIN_JSON);
-        const hopRationale = process.env.TPS_CHAIN_RATIONALE ?? `agent ${from} tps mail send`;
-        const now = new Date().toISOString();
-
-        const chain = priorChain ?? [
-          {
-            agent: "system",
-            kind: "human" as const,
-            timestamp: now,
-            rationale: "tps mail send (no inbound chain)",
-            signature: null,
-          },
-        ];
-
-        chain.push({
-          agent: from,
-          kind: "agent" as const,
-          timestamp: now,
-          rationale: hopRationale,
-          signature: null, // signEnvelope will fill
-        });
-
-        const envelope: Envelope = {
-          v: 1,
-          from,
-          to,
-          subject: `mail to ${to}`,
-          body: args.message,
-          messageId: randomUUID(),
-          timestamp: now,
-          delegationChain: chain,
-        };
-
-        const signed = signEnvelope(envelope, { [from]: privkey });
-        const signedEnvelopeBody = JSON.stringify(signed);
-        args.message = signedEnvelopeBody;
-      } else {
-        console.warn(
-          `No private key found for agent "${from}" — sending unsigned. ` +
-          `Place a 32-byte Ed25519 seed at ~/.flair/keys/${from}.key or set ` +
-          `TPS_TEST_KEYS_DIR to enable envelope signing.`,
-        );
-      }
-
+      // Direct Maildir send: args.message was already signed by
+      // maybeSignEnvelopeBody above.
       const msg = sendMessage(to, args.message, from);
       if (args.json) {
         console.log(JSON.stringify(msg, null, 2));

--- a/packages/cli/test/mail-send-sign.test.ts
+++ b/packages/cli/test/mail-send-sign.test.ts
@@ -283,6 +283,47 @@ describe("tps mail send with signed envelopes", () => {
 
   // ── Test 3: Custom rationale ──────────────────────────────────────────
 
+  // ── Test 5: Branch-office route also ships signed body (gap #1) ────────
+
+  test("branch-office route writes a signed envelope (not raw body)", async () => {
+    // Repro of the rollout gap: pre-PR, the branch-office bridge path
+    // (`tps mail send` → ~/.tps/branch-office/<to>/mail/...) returned BEFORE
+    // the signing block ran, so K&S/branch-office dispatches shipped unsigned.
+    // After the lift, this route ships a signed envelope JSON as body.
+    const home = join(tempRoot, "home");
+    const branchInbox = join(home, ".tps", "branch-office", "anvil", "mail", "inbox");
+    mkdirSync(branchInbox, { recursive: true });
+    writeFileSync(join(keysDir, "flint.key"), FLINT_SEED);
+
+    const result = runMailSend(["anvil", "Dispatch via branch-office"], {
+      HOME: home,
+      TPS_AGENT_ID: "flint",
+      TPS_TEST_KEYS_DIR: keysDir,
+    });
+
+    expect(result.status).toBe(0);
+
+    // Branch-office delivery lands in <branch-office>/<to>/mail/new/<file>.json
+    // (deliverToSandbox writes to mail/new/, not the inbox/ gate-dir).
+    const deliveredDir = join(home, ".tps", "branch-office", "anvil", "mail", "new");
+    const files = readdirSync(deliveredDir).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBe(1);
+
+    const wrapper = JSON.parse(readFileSync(join(deliveredDir, files[0]!), "utf-8"));
+    // The wrapper.body is the signed envelope JSON string.
+    const env = JSON.parse(wrapper.body) as Envelope;
+    expect(env.v).toBe(1);
+    expect(env.from).toBe("flint");
+    expect(env.to).toBe("anvil");
+    expect(env.body).toBe("Dispatch via branch-office");
+    expect(env.delegationChain.length).toBe(2);
+    expect(env.delegationChain[1].signature).toMatch(/^ed25519:/);
+    expect(env.signature).toMatch(/^ed25519:/);
+
+    const vr = await verifyEnvelope(env, mockFlair({ flint: FLINT_SEED }));
+    expect(vr).toEqual({ ok: true });
+  });
+
   test("uses TPS_CHAIN_RATIONALE in the current hop entry", async () => {
     const mailDir = join(tempRoot, "mail");
     writeFileSync(join(keysDir, "flint.key"), FLINT_SEED);


### PR DESCRIPTION
## Summary

Signed-envelopes rollout gap #1: lift `signEnvelope` call above the four delivery routes so all paths ship signed bodies.

Pre-PR, only the direct-maildir route signed. Branch-mode outbox, remote-branch, and branch-office bridge all returned BEFORE the signing block, leaving K&S dispatches and cross-host branch-office traffic effectively unsigned — exactly the kind of "merged but inert" gap that surfaced during the 2026-05-25 rollout smoke-test.

## Change

- Extract signing logic into `maybeSignEnvelopeBody(from, to, body)` helper at module scope
- Call it once right after `resolveAgentId()`, before any route check
- Helper is best-effort: returns original body with the same warning when no private key is present (preserves the PR-3 backward-compat behavior)
- All four delivery paths now ship signed envelope JSON as body

## Tests

- 4 existing sign tests still green (no-chain, with-chain, 4-hop end-to-end, custom rationale)
- +1 new branch-office route test: pre-creates `~/.tps/branch-office/anvil/mail/inbox/`, sends from flint, asserts the file written to `.../mail/new/<file>.json` has `body` = signed envelope JSON with valid Ed25519 signature

5/5 sign tests green. Full cli test suite: 1005 pass / 5 fail. Same 5 failures pre-exist on main (verified by stash diff) — unrelated facts/nono/ssh tests.

## Threading

- Beads: ops-pfy6 (gap #1 from rollout)
- Related: ops-ashh (branch-office routing-misroute — overlapping surface)
- Parent epic: ops-9cyb (TPS signed envelopes)
- Sibling follow-up: ops-ibw8 (gap #2 — openclaw consumer wiring, next PR)