### PR TITLE
fix(mail): normalize PKCS8 agent keys so `tps mail send` signs correctly

### DIFF
--- a/packages/cli/src/utils/agent-keys.ts
+++ b/packages/cli/src/utils/agent-keys.ts
@@ -1,13 +1,24 @@
 /**
  * agent-keys.ts — Read Ed25519 private key seeds for TPS agents.
  *
- * Keys are stored as 32-byte raw seeds in ~/.flair/keys/<agent>.key
- * (mode 0600). For tests, TPS_TEST_KEYS_DIR overrides the key directory.
+ * Keys live in ~/.flair/keys/<agent>.key (mode 0600) in EITHER format the
+ * fleet uses:
+ *   - a raw 32-byte seed (e.g. flint), or
+ *   - base64-encoded PKCS8 DER — the canonical Flair key format used by
+ *     kern/sherlock/anvil/pulse and emitted by
+ *     `openssl pkcs8 -topk8 -nocrypt -outform DER | base64`.
+ *
+ * readAgentPrivateKey normalizes both to the 32-byte seed that @noble/ed25519
+ * signing expects. Historically it returned the raw file bytes and assumed a
+ * 32-byte seed, so signing silently produced invalid signatures for every
+ * agent whose key was stored as base64-PKCS8 (all but flint) — breaking
+ * `tps mail send` for them. For tests, TPS_TEST_KEYS_DIR overrides the dir.
  */
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { createPrivateKey } from "node:crypto";
 
 function keysDir(): string {
   if (process.env.TPS_TEST_KEYS_DIR) {
@@ -17,13 +28,58 @@ function keysDir(): string {
 }
 
 /**
- * Read an agent's Ed25519 private key seed (32 bytes).
- * Returns null if the key file doesn't exist.
+ * Read an agent's Ed25519 private key and return the 32-byte signing seed,
+ * normalizing whichever on-disk format the key is stored in (raw seed or
+ * base64-PKCS8 DER). Returns null if the key file doesn't exist; throws on an
+ * unrecognized format.
  */
 export function readAgentPrivateKey(agentName: string): Buffer | null {
   const path = join(keysDir(), `${agentName}.key`);
   if (!existsSync(path)) return null;
-  return readFileSync(path);
+  return toEd25519Seed(readFileSync(path));
+}
+
+/**
+ * Normalize a stored Ed25519 private key to its raw 32-byte seed.
+ * Exported for unit tests.
+ */
+export function toEd25519Seed(raw: Buffer): Buffer {
+  // Already a raw 32-byte seed (e.g. flint's key).
+  if (raw.length === 32) return raw;
+
+  // base64-encoded PKCS8 DER (canonical Flair key format).
+  const text = raw.toString("utf8").trim();
+  if (text.length > 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(text)) {
+    const seed = seedFromPkcs8Der(Buffer.from(text, "base64"));
+    if (seed) return seed;
+  }
+
+  // Raw (non-base64) PKCS8 DER bytes.
+  const seed = seedFromPkcs8Der(raw);
+  if (seed) return seed;
+
+  throw new Error(
+    `Unrecognized Ed25519 private key format (${raw.length} bytes); ` +
+      `expected a raw 32-byte seed or base64-encoded PKCS8 DER`,
+  );
+}
+
+/**
+ * Extract the 32-byte Ed25519 seed from PKCS8 DER bytes, validating the
+ * structure via node:crypto (no hardcoded ASN.1 offsets). Returns null if the
+ * bytes aren't a valid Ed25519 PKCS8 key.
+ */
+function seedFromPkcs8Der(der: Buffer): Buffer | null {
+  try {
+    const key = createPrivateKey({ key: der, format: "der", type: "pkcs8" });
+    if (key.asymmetricKeyType !== "ed25519") return null;
+    const jwk = key.export({ format: "jwk" }) as { d?: string };
+    if (!jwk.d) return null;
+    const seed = Buffer.from(jwk.d, "base64url");
+    return seed.length === 32 ? seed : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/packages/cli/test/agent-keys.test.ts
+++ b/packages/cli/test/agent-keys.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { generateKeyPairSync, createHash } from "node:crypto";
+import * as ed from "@noble/ed25519";
+import { hashes } from "@noble/ed25519";
+import { toEd25519Seed, readAgentPrivateKey } from "../src/utils/agent-keys.js";
+
+// Wire sync sha512 so @noble sign/verify run synchronously (same as signEnvelope.ts).
+hashes.sha512 = (m: Uint8Array) => new Uint8Array(createHash("sha512").update(m).digest());
+
+/** Mint an Ed25519 keypair and expose every on-disk representation we care about. */
+function makeKey() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const der = privateKey.export({ format: "der", type: "pkcs8" }) as Buffer; // 48-byte PKCS8 DER
+  const b64Pkcs8 = der.toString("base64"); // 64-char base64 — how kern/sherlock/anvil/pulse are stored
+  const seed = Buffer.from((privateKey.export({ format: "jwk" }) as { d: string }).d, "base64url"); // raw 32-byte seed
+  const pub = Buffer.from((publicKey.export({ format: "jwk" }) as { x: string }).x, "base64url"); // raw 32-byte pubkey
+  return { der, b64Pkcs8, seed, pub };
+}
+
+describe("toEd25519Seed", () => {
+  test("passes a raw 32-byte seed through unchanged (flint's format)", () => {
+    const { seed } = makeKey();
+    expect(toEd25519Seed(Buffer.from(seed)).equals(seed)).toBe(true);
+  });
+
+  test("decodes base64-PKCS8 to the 32-byte seed (the broken-before format)", () => {
+    const { b64Pkcs8, seed } = makeKey();
+    const out = toEd25519Seed(Buffer.from(b64Pkcs8, "utf8"));
+    expect(out.length).toBe(32);
+    expect(out.equals(seed)).toBe(true);
+  });
+
+  test("decodes raw PKCS8 DER bytes to the 32-byte seed", () => {
+    const { der, seed } = makeKey();
+    expect(toEd25519Seed(der).equals(seed)).toBe(true);
+  });
+
+  test("the normalized seed signs a payload verifiable by the original pubkey", () => {
+    const { b64Pkcs8, pub } = makeKey();
+    const seed = toEd25519Seed(Buffer.from(b64Pkcs8, "utf8"));
+    const msg = new TextEncoder().encode("tps-mail envelope");
+    const sig = ed.sign(msg, seed);
+    expect(ed.verify(sig, msg, pub)).toBe(true); // would have failed with the un-normalized 64-byte key
+  });
+
+  test("throws on an unrecognized key format", () => {
+    expect(() => toEd25519Seed(Buffer.from([1, 2, 3, 4]))).toThrow(/Unrecognized/);
+  });
+});
+
+describe("readAgentPrivateKey", () => {
+  function withKeysDir<T>(fn: (dir: string) => T): T {
+    const dir = mkdtempSync(join(tmpdir(), "tps-keys-"));
+    const prev = process.env.TPS_TEST_KEYS_DIR;
+    process.env.TPS_TEST_KEYS_DIR = dir;
+    try {
+      return fn(dir);
+    } finally {
+      if (prev === undefined) delete process.env.TPS_TEST_KEYS_DIR;
+      else process.env.TPS_TEST_KEYS_DIR = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("reads + normalizes a base64-PKCS8 key file", () => {
+    const { b64Pkcs8, seed } = makeKey();
+    withKeysDir((dir) => {
+      writeFileSync(join(dir, "kerntest.key"), b64Pkcs8, { mode: 0o600 });
+      const out = readAgentPrivateKey("kerntest");
+      expect(out).not.toBeNull();
+      expect(out!.length).toBe(32);
+      expect(out!.equals(seed)).toBe(true);
+    });
+  });
+
+  test("reads a raw-seed key file unchanged", () => {
+    const { seed } = makeKey();
+    withKeysDir((dir) => {
+      writeFileSync(join(dir, "flinttest.key"), seed, { mode: 0o600 });
+      const out = readAgentPrivateKey("flinttest");
+      expect(out!.equals(seed)).toBe(true);
+    });
+  });
+
+  test("returns null for a missing key", () => {
+    withKeysDir(() => {
+      expect(readAgentPrivateKey("nope")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`readAgentPrivateKey` (`packages/cli/src/utils/agent-keys.ts`) read the key file raw and assumed a **32-byte Ed25519 seed**. Only `flint`'s key is stored that way — `kern`/`sherlock`/`anvil`/`pulse` keys are **64-byte base64-PKCS8 DER** (the canonical Flair key format, `openssl pkcs8 -topk8 -nocrypt -outform DER | base64`). So `@noble` `ed.sign` received the wrong bytes and produced invalid signatures, and **every non-`flint` `tps mail send` silently failed** — the gateway logged the reply as created + acked (`route=outbox`) but it never reached the recipient's inbox.

**Real-world impact:** all three K&S verbal mail verdicts on a spec review last night were lost this way (PR reviews still land because K&S post to GitHub directly; it's the verbal-mail channel that breaks). The verdicts were recovered from the agents' OpenClaw session transcripts.

## Fix

`readAgentPrivateKey` now normalizes either on-disk format to the 32-byte seed via a new exported `toEd25519Seed()`:
- 32-byte input → raw seed, unchanged
- base64-PKCS8 / raw PKCS8 DER → seed extracted via `node:crypto` `createPrivateKey` + JWK `d` export (structure-validated; **no hardcoded ASN.1 offsets**)
- anything else → throws a clear error

## Tests (`packages/cli/test/agent-keys.test.ts`, 8 passing)

raw / base64-PKCS8 / raw-DER normalization, the unrecognized-format throw, `readAgentPrivateKey` via `TPS_TEST_KEYS_DIR`, and a **sign→verify round-trip** proving the normalized seed signs verifiably against the original public key. Also verified end-to-end against real keys: `flint`'s seed derives `flint`'s registered public key.

## Deploy note

`dist` is gitignored — after merge, `~/ops/tps` needs a pull + rebuild for `tps mail send` to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)