### PR TITLE
fix(relay): boundary-check team.json workspaceMail delivery path (ops-23)

### DIFF
--- a/packages/cli/src/utils/relay.ts
+++ b/packages/cli/src/utils/relay.ts
@@ -1,5 +1,5 @@
 import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { sanitizeIdentifier } from "../schema/sanitizer.js";
@@ -34,6 +34,18 @@ export function resolveAgentMailRoot(agentId: string): string {
   return resolveDeliveryPath(agentId);
 }
 
+/**
+ * True if `p` resolves to within ~/.tps/branch-office (the only place a delivery
+ * path may point). Mirrors assertOfficeDir in wall.ts / internal-mail.ts so a
+ * team.json `workspaceMail` value can't redirect mail writes outside the office
+ * root via path traversal or an absolute path (ops-23).
+ */
+function isWithinBranchOffice(p: string): boolean {
+  const resolved = resolve(p);
+  const root = resolve(join(process.env.HOME || homedir(), ".tps", "branch-office"));
+  return resolved === root || resolved.startsWith(root + sep);
+}
+
 function resolveDeliveryPath(agentId: string): string {
   const branchDir = join(process.env.HOME || homedir(), ".tps", "branch-office");
   if (!existsSync(branchDir)) return join(branchDir, agentId, "mail");
@@ -44,7 +56,10 @@ function resolveDeliveryPath(agentId: string): string {
   if (existsSync(teamSidecar)) {
     try {
       const sidecar = JSON.parse(readFileSync(teamSidecar, "utf-8"));
-      if (sidecar.workspaceMail) return sidecar.workspaceMail;
+      if (sidecar.workspaceMail) {
+        if (isWithinBranchOffice(sidecar.workspaceMail)) return sidecar.workspaceMail;
+        swarn(`team.json workspaceMail out of bounds, ignoring: ${sidecar.workspaceMail}`);
+      }
     } catch {}
     return join(teamPath, "workspace", "mail");
   }
@@ -59,7 +74,9 @@ function resolveDeliveryPath(agentId: string): string {
       const sidecarPath = join(branchDir, team, "team.json");
       const sidecar = JSON.parse(readFileSync(sidecarPath, "utf-8"));
       if (Array.isArray(sidecar.members) && sidecar.members.includes(agentId)) {
-        return sidecar.workspaceMail || join(branchDir, team, "workspace", "mail");
+        if (sidecar.workspaceMail && isWithinBranchOffice(sidecar.workspaceMail)) return sidecar.workspaceMail;
+        if (sidecar.workspaceMail) swarn(`team.json workspaceMail out of bounds, ignoring: ${sidecar.workspaceMail}`);
+        return join(branchDir, team, "workspace", "mail");
       }
     }
   } catch {

--- a/packages/cli/test/relay.test.ts
+++ b/packages/cli/test/relay.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { deliverToSandbox, processOutboxOnce } from "../src/utils/relay.js";
+import { deliverToSandbox, processOutboxOnce, resolveAgentMailRoot } from "../src/utils/relay.js";
 
 function writeJson(path: string, obj: unknown) {
   writeFileSync(path, JSON.stringify(obj, null, 2), "utf-8");
@@ -168,6 +168,52 @@ describe("relay utils", () => {
     const msg = JSON.parse(readFileSync(join(inbox, files[0]!), "utf-8"));
     expect(msg.to).toBe("member1");
     expect(msg.body).toBe("hello team member");
+  });
+
+  test("ignores out-of-bounds workspaceMail on a team and falls back to safe default (ops-23)", () => {
+    const teamDir = join(root, ".tps", "branch-office", "team1");
+    // Misconfigured/hostile team.json: workspaceMail escaping the office root.
+    const escape = join(root, "evil-mail");
+    mkdirSync(teamDir, { recursive: true });
+    writeJson(join(teamDir, "team.json"), {
+      teamId: "team1",
+      members: ["member1"],
+      workspaceMail: escape,
+      createdAt: new Date().toISOString(),
+    });
+
+    const resolved = resolveAgentMailRoot("team1");
+    expect(resolved).toBe(join(teamDir, "workspace", "mail"));
+    expect(resolved).not.toBe(escape);
+  });
+
+  test("ignores out-of-bounds workspaceMail for a team member and falls back to safe default (ops-23)", () => {
+    const teamDir = join(root, ".tps", "branch-office", "team1");
+    // Traversal that resolves outside ~/.tps/branch-office.
+    const escape = join(teamDir, "..", "..", "..", "escape", "mail");
+    mkdirSync(teamDir, { recursive: true });
+    writeJson(join(teamDir, "team.json"), {
+      teamId: "team1",
+      members: ["member1"],
+      workspaceMail: escape,
+      createdAt: new Date().toISOString(),
+    });
+
+    const resolved = resolveAgentMailRoot("member1");
+    expect(resolved).toBe(join(teamDir, "workspace", "mail"));
+  });
+
+  test("returns an in-bounds workspaceMail unchanged (ops-23 regression guard)", () => {
+    const teamDir = join(root, ".tps", "branch-office", "team1");
+    const legit = join(teamDir, "workspace", "mail");
+    mkdirSync(teamDir, { recursive: true });
+    writeJson(join(teamDir, "team.json"), {
+      teamId: "team1",
+      members: ["member1"],
+      workspaceMail: legit,
+      createdAt: new Date().toISOString(),
+    });
+    expect(resolveAgentMailRoot("member1")).toBe(legit);
   });
 
   test("relay pauses duplicate messages (loop detection)", async () => {


### PR DESCRIPTION
Fixes ops-23 (S17.2.5-C).

## Problem

`resolveDeliveryPath` (`packages/cli/src/utils/relay.ts`) reads `workspaceMail` from a team's `team.json` and returns it **verbatim** as the mail delivery root — with no check that it stays under `~/.tps/branch-office/`. A traversal or absolute path in `team.json` would redirect mail writes outside the office root. This is inconsistent with the `assertOfficeDir` guard already enforced in `wall.ts` and `internal-mail.ts`.

Low risk today (team.json is host-side, written by trusted provisioning) but a defense-in-depth gap.

## Fix

- Add `isWithinBranchOffice()` mirroring `assertOfficeDir`'s boundary logic (`resolve()` + `startsWith(root + sep)`).
- Validate `workspaceMail` at both return sites (team-root case and team-member case).
- An out-of-bounds value is **warned and ignored**, falling back to the safe per-team default. Graceful fallback fits `resolveDeliveryPath`'s existing semantics (it already degrades to a default on any read error) better than throwing — and a throw would just be swallowed by the existing try/catch and fall back anyway, minus the log.

## Tests

`packages/cli/test/relay.test.ts`:
- out-of-bounds `workspaceMail` on a team → safe default
- out-of-bounds `workspaceMail` for a team member → safe default
- in-bounds `workspaceMail` returned unchanged (regression guard)

relay suite **11/11 green**. Full cli suite **1016 pass**; the 5 remaining failures (ssh-reachability, `nono`-on-PATH, external-command verify) are pre-existing/environmental and untouched by this change — confirmed identical on a clean `main` checkout (my change stashed).

## Notes

- The boundary logic now appears in three resolvers (`wall.ts`, `internal-mail.ts`, `relay.ts`). Worth extracting to a shared util in a follow-up; kept local here to keep the fix focused.
- Only the canonical `packages/cli/src/utils/relay.ts` is changed. A legacy `src/utils/relay.ts` exists at the repo root but is pre-monorepo cruft (not in the build chain). Out of scope; flagging for possible cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
