### PR TITLE
Mail-watch onPoll liveness heartbeat hook (ops-i3vw)

### DIFF
--- a/packages/cli/src/commands/mail-watch.ts
+++ b/packages/cli/src/commands/mail-watch.ts
@@ -46,6 +46,15 @@ export interface MailWatchOptions {
   maxConcurrent?: number;
   /** Polling-fallback interval in ms — guards against fs.watch going deaf (default: 15000) */
   pollMs?: number;
+  /**
+   * Liveness heartbeat fired once per poll cycle (ops-i3vw — Flair Presence dogfood).
+   * Binding the heartbeat to the SAME poll loop that delivers mail means a stalled
+   * or dead watcher stops beating — so its Presence record goes stale and the
+   * staleness monitor flags it. This directly catches the 2026-06-25 failure
+   * (a watcher stalled 13h with nothing recording its liveness). Errors are
+   * swallowed: a heartbeat failure must never crash the mail loop.
+   */
+  onPoll?: () => void | Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -200,11 +209,25 @@ export function watchMail(opts: MailWatchOptions): MailWatcher {
   // Reliability > idle CPU for the review/mail pipeline.
   const watcher = fsWatch(inbox.fresh, onFsEvent);
   const pollMs = opts.pollMs ?? 15_000;
-  const pollTimer = setInterval(() => { void processNew(); }, pollMs);
+
+  // Liveness heartbeat — fire once per GUARANTEED poll cycle (not the fs-event
+  // path, which can go deaf). A heartbeat error never propagates: it must not
+  // crash the mail loop. If the watcher stalls/dies, the heartbeat stops with
+  // it → Presence goes stale → the staleness monitor flags it. (ops-i3vw)
+  const beat = () => {
+    if (stopped || !opts.onPoll) return;
+    Promise.resolve()
+      .then(() => opts.onPoll!())
+      .catch(() => { /* heartbeat failure must not crash the watcher */ });
+  };
+
+  const pollTimer = setInterval(() => { void processNew(); beat(); }, pollMs);
 
   // Deliver anything already waiting in new/ at (re)start, immediately — so a
   // kickstart RECOVERS stuck mail instead of waiting for the first event/poll.
   void processNew();
+  // Beat once at startup so a fresh (re)start registers liveness immediately.
+  beat();
 
   return {
     stop() {
@@ -411,11 +434,28 @@ export async function runMailWatch(args: MailWatchArgs): Promise<void> {
     ? { args: args.hook }
     : undefined;
 
+  // Flair Presence heartbeat (ops-i3vw) — DEFAULT-OFF, byte-identical when off.
+  // Enable per-agent by setting TPS_PRESENCE_BEAT_CMD to an executable that
+  // emits the agent's Presence (it reads TPS_AGENT_ID / FLAIR_AGENT_ID). The
+  // watcher fires it once per poll cycle; failures are swallowed inside watchMail.
+  const beatCmd = process.env.TPS_PRESENCE_BEAT_CMD;
+  const onPoll: (() => void) | undefined = beatCmd
+    ? () => {
+        // Fire-and-forget; never block or crash the mail loop. No shell interp.
+        const child = spawn(beatCmd, [], {
+          env: { ...process.env, FLAIR_AGENT_ID: process.env.FLAIR_AGENT_ID ?? args.agent, TPS_AGENT_ID: process.env.TPS_AGENT_ID ?? args.agent },
+          stdio: "ignore",
+        });
+        child.on("error", () => { /* heartbeat failure must not crash the watcher */ });
+      }
+    : undefined;
+
   const watcher = watchMail({
     agent: args.agent,
     debounceMs: args.debounce,
     hook,
     maxConcurrent: 3,
+    onPoll,
     onMessage: (msg) => {
       if (args.json) {
         console.log(JSON.stringify(msg));

--- a/packages/cli/test/mail-watch.test.ts
+++ b/packages/cli/test/mail-watch.test.ts
@@ -133,6 +133,41 @@ describe("watchMail (fs.watch)", () => {
     expect(received.filter((id) => id === "dedup-msg")).toHaveLength(1);
   });
 
+  it("fires onPoll once at startup and on each poll cycle (liveness heartbeat, ops-i3vw)", async () => {
+    makeInbox(tmp, "test-agent");
+    let beats = 0;
+    const watcher = watchMail({
+      agent: "test-agent",
+      debounceMs: 20,
+      pollMs: 40, // fast poll for the test
+      onPoll: () => { beats++; },
+    });
+
+    await sleep(150); // startup beat + ~3 poll cycles at 40ms
+    watcher.stop();
+    // At least the startup beat plus a couple poll beats.
+    expect(beats).toBeGreaterThanOrEqual(2);
+  });
+
+  it("a throwing onPoll never crashes the watcher (heartbeat failure is swallowed)", async () => {
+    const { fresh } = makeInbox(tmp, "test-agent");
+    const received: string[] = [];
+    const watcher = watchMail({
+      agent: "test-agent",
+      debounceMs: 20,
+      pollMs: 40,
+      onPoll: () => { throw new Error("simulated heartbeat failure"); },
+      onMessage: (msg) => { received.push(msg.id); },
+    });
+
+    await sleep(60);
+    // Mail delivery must still work despite a throwing heartbeat.
+    writeMsg(fresh, "after-bad-beat", "sender", "test-agent", "still alive");
+    await sleep(150);
+    watcher.stop();
+    expect(received).toContain("after-bad-beat");
+  });
+
   it("handles ENOENT gracefully when file is moved before read", async () => {
     const { fresh, cur } = makeInbox(tmp, "test-agent");
 


### PR DESCRIPTION
Binds an optional per-poll heartbeat to the mail-watcher poll loop, so a stalled watcher stops beating -> its Flair Presence goes stale -> the staleness monitor flags it (catches the 2026-06-25 sherlock-stall class at the source). Wired via TPS_PRESENCE_BEAT_CMD: default-off and byte-identical when unset; spawned with args[] (no shell interp). +2 tests (heartbeat fires per cycle; a throwing onPoll does not crash delivery); same pre-existing failures as main (zero regression). Part of ops-i3vw (dogfood Flair Presence). Touches the mail/exec path — Sherlock-hard.