### PR TITLE
fix(mail-watch): ProcessType=Background so macOS stops idle-reaping the per-agent watcher (ops-bayh)

### DIFF
--- a/packages/cli/src/commands/mail-watch.ts
+++ b/packages/cli/src/commands/mail-watch.ts
@@ -269,7 +269,11 @@ export function xmlEscape(s: string): string {
     .replace(/'/g, "&apos;");
 }
 
-function buildPlist(agent: string, tpsBin: string, extraHookArgs: string[]): string {
+/**
+ * Build the launchd plist for an agent's mail-watch daemon.
+ * Exported for unit testing (asserts ProcessType=Background + valid XML).
+ */
+export function buildPlist(agent: string, tpsBin: string, extraHookArgs: string[]): string {
   const label = plistLabel(agent);
   const stdout = join(logDir(), `mail-watch-${agent}.log`);
   const stderr = join(logDir(), `mail-watch-${agent}.error.log`);
@@ -309,8 +313,18 @@ ${progArgs}
     <true/>
   </dict>
 
+  <!--
+    ProcessType=Background tells launchd this is a long-lived background daemon.
+    Without it, the watcher's idle poll timer (waking every ~15s) gets the job
+    power-classified as "inefficient" and macOS reaps it with a clean exit 0 —
+    which KeepAlive(Crashed:true) does NOT restart, so the agent goes silently
+    deaf. Background processing type opts the job out of that idle-reap. (ops-bayh)
+  -->
+  <key>ProcessType</key>
+  <string>Background</string>
+
   <key>ThrottleInterval</key>
-  <integer>5</integer>
+  <integer>10</integer>
 
   <key>StandardOutPath</key>
   <string>${xmlEscape(stdout)}</string>

--- a/packages/cli/test/mail-watch.test.ts
+++ b/packages/cli/test/mail-watch.test.ts
@@ -13,7 +13,9 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { validateAgentId, watchMail, xmlEscape } from "../src/commands/mail-watch.js";
+import { buildPlist, validateAgentId, watchMail, xmlEscape } from "../src/commands/mail-watch.js";
+import { execFileSync } from "node:child_process";
+import { platform } from "node:os";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -285,6 +287,43 @@ describe("xmlEscape", () => {
     expect(escaped).not.toContain(">");
     expect(escaped).toContain("&lt;");
     expect(escaped).toContain("&gt;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPlist — generated launchd plist shape (ops-bayh: idle-reap immunity)
+// ---------------------------------------------------------------------------
+
+describe("buildPlist", () => {
+  it("sets ProcessType=Background so macOS does not idle-reap the watcher", () => {
+    const xml = buildPlist("test-agent", "/usr/local/bin/tps.js", []);
+    expect(xml).toContain("<key>ProcessType</key>");
+    // The <string> follows the <key> on the next line — assert the pairing.
+    expect(xml).toMatch(/<key>ProcessType<\/key>\s*<string>Background<\/string>/);
+  });
+
+  it("sets a non-zero ThrottleInterval", () => {
+    const xml = buildPlist("test-agent", "/usr/local/bin/tps.js", []);
+    expect(xml).toMatch(/<key>ThrottleInterval<\/key>\s*<integer>10<\/integer>/);
+  });
+
+  it("keeps KeepAlive(Crashed:true) so a real crash still restarts", () => {
+    const xml = buildPlist("test-agent", "/usr/local/bin/tps.js", []);
+    expect(xml).toMatch(/<key>KeepAlive<\/key>\s*<dict>\s*<key>Crashed<\/key>\s*<true\/>/);
+  });
+
+  it("generates plist that passes plutil -lint (valid XML, macOS only)", () => {
+    if (platform() !== "darwin") return; // plutil is macOS-only
+    const xml = buildPlist("test-agent", "/usr/local/bin/tps.js", ["arg with spaces & <special>"]);
+    const tmpFile = join(tmpdir(), `buildplist-lint-${Date.now()}.plist`);
+    writeFileSync(tmpFile, xml);
+    try {
+      // Throws (non-zero exit) if the plist is malformed.
+      const out = execFileSync("plutil", ["-lint", tmpFile], { encoding: "utf-8" });
+      expect(out).toContain("OK");
+    } finally {
+      rmSync(tmpFile, { force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Problem (root cause)

The per-agent mail-watch launchd daemon installed by `tps mail watch <agent> --daemon install` was getting reaped by macOS. `buildPlist()` generated a plist with **no `ProcessType`**. The watcher's idle poll timer wakes roughly every 15s; with no `ProcessType`, launchd/macOS power-classifies the job as "inefficient" and reaps it with a **clean exit 0**.

The generated `KeepAlive` is `Crashed: true` only — so a clean exit-0 is **not** restarted. The result: the watcher dies silently (no crash, no error log), the agent stops consuming mail, and dispatches strand in `new/`. This is the recurring watcher-stall failure mode (ops-bayh / ops-bkx1; the 2026-06-25 13h stall).

The live single hand-stabilized plist already had `ProcessType=Background` applied by hand. This PR makes the **durable per-agent-daemon code path** correct so the fix survives reinstalls and we can migrate off the hand-rolled `~/.tps/bin/tps-mail-watch` bash wrapper (whose asymmetric `wait` lets one dead child silently deafen an agent).

## Fix

`buildPlist()` now emits:

```xml
<key>ProcessType</key>
<string>Background</string>
```

`ProcessType=Background` tells launchd the job is a long-lived background daemon and opts it out of the idle/efficiency reap. `ThrottleInterval` bumped 5 → 10. `KeepAlive(Crashed: true)` is **preserved** so a genuine crash still restarts.

## Verification

- Exported `buildPlist` and added unit tests asserting `ProcessType=Background`, `ThrottleInterval=10`, preserved `KeepAlive(Crashed:true)`, and `plutil -lint` validity of the generated XML (with a malicious exec arg, to exercise xmlEscape).
- Traced the install path end-to-end (`runMailWatch` → `installDaemon` → `buildPlist` → `writeFileSync`) and generated a sample plist via the real function: `plutil -lint` → OK; `plutil -extract ProcessType raw` → `Background`; `ThrottleInterval` → `10`; `KeepAlive.Crashed` → `true`.
- `tsc` typecheck + dist build clean (dependency order: cli bootstrap → agent → cli → pi-tps-mail).
- mail-watch tests: 19 pass / 0 fail. Full CLI suite: 1025 pass / 5 fail — the **5 failures are pre-existing on `origin/main`** (verified by stashing this change and re-running: identical 5 fail / same names). They are environmental: `nono` not on PATH, real-SSH reachability timeout, verify subprocess, type-coercion, memory-promotion. Agent suite: 82 pass / 0 fail. `pi-tps-mail`: no tests.
- Biome lint introduces **zero new diagnostics** from the changed lines (the 2 warnings in `mail-watch.ts` are the pre-existing `opts.onPoll!()` non-null assertions from PR #317).

## Out of scope (FIX 2 — deliver-hook timeout)

The `openclaw-deliver` hook (`openclaw agent --timeout 600`) that pins a handler slot for 10 min is **not in this repo** — it exists only as an installed file at `~/.tps/bin/hooks/openclaw-deliver.sh` (the repo's `plugins/openclaw-tps-mail/README.md` even documents deleting it). No repo source, script, or template contains a `--timeout 600` invocation. The 600→180 tightening is a local-only `~/.tps` edit and is **not** part of this PR.

Refs: ops-bayh, ops-bkx1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)