### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs — fixes red Semgrep SAST gate (19 mutable-action-tag findings)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Determine version
         id: version
@@ -42,20 +42,20 @@ jobs:
           fi
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Release Preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Verify tag is on main
@@ -61,8 +61,8 @@ jobs:
             artifact: tps-linux-x64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.10"
       - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
@@ -94,7 +94,7 @@ jobs:
           chmod +x /tmp/release/${PKG}/tps
           cp packages/${PKG}/README.md /tmp/release/${PKG}/README.md
       - name: Upload staging artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.pkg }}
           path: /tmp/release/${{ matrix.pkg }}
@@ -105,8 +105,8 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.10"
       - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
@@ -140,12 +140,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: /tmp/release
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           registry-url: https://registry.npmjs.org/
@@ -155,7 +155,7 @@ jobs:
           cp -R /tmp/release/cli-darwin-x64/. packages/cli-darwin-x64/
           cp -R /tmp/release/cli-linux-arm64/. packages/cli-linux-arm64/
           cp -R /tmp/release/cli-linux-x64/. packages/cli-linux-x64/
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.10"
       - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
@@ -214,7 +214,7 @@ jobs:
     needs: [build-binaries, publish-packages]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: /tmp/release
       - name: Create release artifacts
@@ -224,7 +224,7 @@ jobs:
           cat /tmp/release/cli-linux-arm64/tps-linux-arm64.sha256
           cat /tmp/release/cli-linux-x64/tps-linux-x64.sha256
       - name: Publish checksums to GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
             /tmp/release/cli-darwin-arm64/tps-darwin-arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,8 +129,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
         with:
           languages: javascript-typescript
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3


### PR DESCRIPTION
Fixes the red Semgrep SAST gate blocking every cli PR. **All 19 findings were one rule** — `yaml.github-actions.security.github-actions-mutable-action-tag` (unpinned GitHub Actions on floating `@vN` tags). Pure supply-chain hygiene; **zero** application-security findings (no injection/traversal/crypto/tainted-input).

## What
Pinned every GitHub Action to its **commit SHA** (`actions/checkout@v4` → `@34e1148…# v4`, etc.) across `docker.yml` / `release.yml` / `test.yml`. Each SHA was resolved via `gh api repos/<action>/commits/<tag>` **and cross-verified against `git/refs/tags/<tag>`** — both agree, so these are the real commits the tags point to, not guessed.

## Notably
- **No suppressions, no `--exclude-rule` additions, no escalations.** Nothing was hidden to force green — every finding was a genuine hardening gap and got fixed. A mutable tag can be re-pointed at malicious code by a compromised action repo; an immutable SHA can't. This is a real supply-chain improvement, not just gate-appeasement.
- Semgrep: **19 → 0** (re-run locally after the fix). Workflows-only changeset; no source touched.

Unblocks the pipeline (including the DESIGN.md docs PR #319).

@tps-sherlock please scrutinize: are all 19 genuinely the mutable-tag rule (not a real finding quietly pinned-around), are the SHAs the correct ones for each tag, and is "pin, don't suppress" the right disposition? @tps-kern the pinning approach + any action that should be tracked for updates. Prose, no code spans.
