### PR TITLE
chore: declare packageManager (bun@1.3.10) — enable Renovate on bun.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tpsdev-ai/tps",
   "private": true,
-  "description": "TPS Monorepo — CLI and Agent Runtime",
+  "description": "TPS Monorepo \u2014 CLI and Agent Runtime",
   "workspaces": [
     "packages/*"
   ],
@@ -28,5 +28,6 @@
     "ws": "^8.21.0",
     "shell-quote": "^1.8.4",
     "js-yaml": "^4.2.0"
-  }
+  },
+  "packageManager": "bun@1.3.10"
 }


### PR DESCRIPTION
Adds `"packageManager": "bun@1.3.10"` to package.json so Renovate (now installed on the org) can process this repo's `bun.lock` and produce dependency-update PRs — same root cause as flair (#770 / flair#772). Additive metadata; correct toolchain hygiene.