### PR TITLE
fix(deps): resolve 3 high DoS-class advisories (shell-quote, brace-expansion, js-yaml)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,8 +138,9 @@
     },
   },
   "overrides": {
-    "js-yaml": "^4.2.0",
-    "shell-quote": "^1.8.4",
+    "brace-expansion": "^2.1.2",
+    "js-yaml": "^4.3.0",
+    "shell-quote": "^1.9.0",
     "ws": "^8.21.0",
   },
   "packages": {
@@ -235,7 +236,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+    "brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
 
     "canonicalize": ["canonicalize@3.0.0", "", { "bin": { "canonicalize": "bin/canonicalize.js" } }, "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA=="],
 
@@ -299,7 +300,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": "cli.js" }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
@@ -359,7 +360,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+    "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   },
   "overrides": {
     "ws": "^8.21.0",
-    "shell-quote": "^1.8.4",
-    "js-yaml": "^4.2.0"
+    "shell-quote": "^1.9.0",
+    "js-yaml": "^4.3.0",
+    "brace-expansion": "^2.1.2"
   },
   "packageManager": "bun@1.3.10"
 }


### PR DESCRIPTION
## Summary

Resolves the three high DoS-class advisories flagged by `bun audit` on the CI Dependency Audit lane (#323). All three are pinned via the root `package.json` `overrides` block, so the fix is a version bump there plus the resulting lockfile update — no source changes.

| Advisory | Package | From | To | Pulled in by |
|---|---|---|---|---|
| GHSA-395f-4hp3-45gv (quadratic-complexity DoS in `parse()`) | shell-quote | 1.8.4 | 1.9.0 | `react-devtools-core` (devDependency) |
| GHSA-3jxr-9vmj-r5cp (exponential-time DoS via consecutive non-expanding `{}` groups) | brace-expansion | 2.1.0 | 2.1.2 | `glob` → `minimatch` in the `pi-tps-mail` workspace |
| GHSA-52cp-r559-cp3m (YAML merge-key chains force quadratic CPU) | js-yaml | 4.2.0 | 4.3.0 | `agent` and `cli` workspaces (direct dependency) |

shell-quote and js-yaml were already pinned via `overrides` at vulnerable versions (`^1.8.4`, `^4.2.0`); those were bumped to the patched minor (`^1.9.0`, `^4.3.0`). brace-expansion had no existing override — `glob@10.5.0` (the newest version satisfying `pi-tps-mail`'s existing `^10.4.5` range) still resolves an unpatched `minimatch`/`brace-expansion`, and jumping `glob` to a new major was out of scope for a dependency-only patch, so a new `brace-expansion: ^2.1.2` override was added instead. All three bumps stay within the semver range already required by their respective parents (`^1.6.1`, `^2.0.2`, `^4.1.0`), so no forced major upgrades.

**js-yaml manifest-load path**: the CLI parses `tps.yaml` manifests via `js-yaml`'s `load()` in `packages/cli/src/utils/manifest.ts`, `packages/cli/src/schema/manifest.ts`, `packages/cli/bin/tps.ts`, and `packages/agent/src/config.ts` — all call the default `load()`/`DEFAULT_SCHEMA` path (none restrict to `FAILSAFE_SCHEMA`/`JSON_SCHEMA`), and js-yaml's `DEFAULT_SCHEMA` includes the merge-key (`<<`) type. So the merge-key quadratic-CPU path is reachable from manifest loading for any `tps.yaml` file whose content an attacker controls (e.g. a manifest discovered via `discoverManifests` in an untrusted agent directory). The version bump closes this path; no schema-hardening change was made since it's out of scope for a dependency-only PR.

## Verification

- `bun audit`: 0 vulnerabilities (was 3 high).
- Full test suite (`bun run build && bun run test`, matching the CI `test` job): 1031 pass / 5 fail, 2897 `expect()` calls across 1036 tests in 112 files — identical pass/fail counts and identical failing tests reproduced on unmodified `main` before this change, confirming the 5 failures are pre-existing environment-specific issues (missing `/bin/grep` in this sandbox, an SSH-reachability timeout, and a PATH-dependent nono test), not caused by this bump.

## Test plan

- [x] `bun audit` clean
- [x] `bun run build` succeeds
- [x] `bun run test` (full suite) — same pass/fail counts as baseline `main`

Closes #323
